### PR TITLE
Fix/profile navigation guest mode

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -49,6 +50,8 @@ import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun ProfileScreen(
@@ -57,6 +60,9 @@ fun ProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel
 ) {
 
+    LaunchedEffect  (Unit){
+        userProfileViewModel.fetchUserData(FirebaseAuth.getInstance().currentUser?.uid ?: "")
+    }
   val profileState = userProfileViewModel.userState.collectAsState()
 
   when (val profile = profileState.value) {

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -74,6 +74,12 @@ fun ProfileScreen(
 fun LoadingScreen(navigationActions: NavigationActions) {
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("loadingScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
       topBar = {
         TopAppBar(
             title = { Text("Profile") },

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -50,7 +50,6 @@ import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 
 @Composable
@@ -60,9 +59,9 @@ fun ProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel
 ) {
 
-    LaunchedEffect  (Unit){
-        userProfileViewModel.fetchUserData(FirebaseAuth.getInstance().currentUser?.uid ?: "")
-    }
+  LaunchedEffect(Unit) {
+    userProfileViewModel.fetchUserData(FirebaseAuth.getInstance().currentUser?.uid ?: "")
+  }
   val profileState = userProfileViewModel.userState.collectAsState()
 
   when (val profile = profileState.value) {


### PR DESCRIPTION
Also put a line so that the profile screen appears after the first time we launch the app and create the profile. Before, we had to launch the app, create the profile, then to see the profile we had to close the app and launch it again and only from that point, the profile appeared.