### PR TITLE
Configure CI for Signed APK Generation and Deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - setup/addApk2
 
   pull_request:
     types:
@@ -123,3 +124,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --parallel --build-cache -Dsonar.projectKey=SwEnt-2024-Group-19_Activities -Dsonar.organization=swent-2024-group-19
+
+
+      # New Steps: Building the Signed APK
+
+      - name: Decode the base64-encoded keystore
+        run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ./keystore.jks
+
+      - name: Build Signed APK
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease \
+          -Pandroid.injected.signing.store.file=$KEYSTORE_PATH \
+          -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+          -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+          -Pandroid.injected.signing.key.password=$KEY_PASSWORD
+      - name: Upload Signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: release apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,21 @@ android {
             enableAndroidTestCoverage = true
         }
     }
-
+    // Load the API key from local.properties
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+    signingConfigs {
+        create("release") {
+            // Resolve the keystore path safely
+            storeFile = file("keystore/keystore.jks")
+            storePassword = (System.getenv("KEYSTORE_PASSWORD") ?: properties["KEYSTORE_PASSWORD"]) as String?
+            keyAlias = (System.getenv("KEY_ALIAS") ?: properties["KEY_ALIAS"]) as String?
+            keyPassword = (System.getenv("KEY_PASSWORD") ?: properties["KEY_PASSWORD"]) as String?
+        }
+    }
     testCoverage {
         jacocoVersion = "0.8.8"
     }


### PR DESCRIPTION
Added GitHub Actions workflow to automatically build and sign APK for each release.
Integrated signing configuration in build.gradle.kts using environment variables for keystore path, alias, and passwords.
This setup enables seamless APK generation for testing and deployment at the end of every sprint.(you still have to upload the released apk to diawi.com to get the link to install the app)
