### PR TITLE
Feature/auth/already logged in

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
@@ -124,29 +124,25 @@ class ChooseAccountScreenTest {
     verify(navigationActions).navigateTo(Screen.OVERVIEW)
   }
 
-
-    @Test
-    fun displaysPlaceholder_whenProfileImageUrlIsEmpty() {
-        // Setup the mock user profile with an empty photo URL
-        val userProfile = User(
+  @Test
+  fun displaysPlaceholder_whenProfileImageUrlIsEmpty() {
+    // Setup the mock user profile with an empty photo URL
+    val userProfile =
+        User(
             name = "John Doe",
             photo = "",
             interests = listOf(),
             surname = "Doe",
             id = "123",
-            activities = listOf()
-        )
-        whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
+            activities = listOf())
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
 
-        // Set the content once for this test
-        composeTestRule.setContent {
-            ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
-        }
-
-        // Check that the profile picture node exists, regardless of URL content
-        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    // Set the content once for this test
+    composeTestRule.setContent {
+      ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
     }
 
-
-
+    // Check that the profile picture node exists, regardless of URL content
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
@@ -1,0 +1,152 @@
+package com.android.sample.ui.authentication
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.sample.model.auth.SignInRepository
+import com.android.sample.model.auth.SignInViewModel
+import com.android.sample.model.profile.ProfileViewModel
+import com.android.sample.model.profile.User
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.whenever
+
+class ChooseAccountScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var signInViewModel: SignInViewModel
+  private lateinit var profileViewModel: ProfileViewModel
+  lateinit var signInRepository: SignInRepository
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    signInViewModel = mock(SignInViewModel::class.java)
+    profileViewModel = mock(ProfileViewModel::class.java)
+    signInRepository = mock(SignInRepository::class.java) // Mock the repository
+
+    doNothing().whenever(signInRepository).signOut()
+  }
+
+  @Test
+  fun allElementsAreDisplayed() {
+    // Setup a default mock user profile
+    val userProfile =
+        User(
+            name = "John Doe",
+            photo = "https://example.com/photo.jpg",
+            interests = listOf(),
+            surname = "Doe",
+            id = "123",
+            activities = listOf())
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
+
+    // Set the content once for this test
+    composeTestRule.setContent {
+      ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
+    }
+
+    // Check all elements are displayed
+    composeTestRule.onNodeWithTag("chooseAccountScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("greetingText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("continueText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("switchAccountButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysGreetingTextAndProfileImage_whenUserProfileIsNotNull() {
+    // Setup the mock user profile with a non-null user
+    val userProfile =
+        User(
+            name = "John Doe",
+            photo = "https://example.com/photo.jpg",
+            interests = listOf(),
+            surname = "Doe",
+            id = "123",
+            activities = listOf())
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
+
+    // Set the content once for this test
+    composeTestRule.setContent {
+      ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
+    }
+
+    // Check greeting text and profile image
+    composeTestRule.onNodeWithText("Hello John Doe, you are already signed in!").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysDefaultGreeting_whenUserProfileIsNull() {
+    // Setup the mock user profile to return null
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(null))
+
+    // Set the content once for this test
+    composeTestRule.setContent {
+      ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
+    }
+
+    // Check default greeting text
+    composeTestRule.onNodeWithText("Hello User, you are already signed in!").assertIsDisplayed()
+  }
+
+  @Test
+  fun clickableContinueText_navigatesToOverview() {
+    // Setup a default mock user profile
+    val userProfile =
+        User(
+            name = "John Doe",
+            photo = "https://example.com/photo.jpg",
+            interests = listOf(),
+            surname = "Doe",
+            id = "123",
+            activities = listOf())
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
+
+    // Set the content once for this test
+    composeTestRule.setContent {
+      ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
+    }
+
+    // Perform click on "Continue" text and verify navigation
+    composeTestRule.onNodeWithText("Continue as John Doe").assertIsDisplayed().performClick()
+
+    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+  }
+
+
+    @Test
+    fun displaysPlaceholder_whenProfileImageUrlIsEmpty() {
+        // Setup the mock user profile with an empty photo URL
+        val userProfile = User(
+            name = "John Doe",
+            photo = "",
+            interests = listOf(),
+            surname = "Doe",
+            id = "123",
+            activities = listOf()
+        )
+        whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
+
+        // Set the content once for this test
+        composeTestRule.setContent {
+            ChooseAccountScreen(navigationActions, signInViewModel, profileViewModel)
+        }
+
+        // Check that the profile picture node exists, regardless of URL content
+        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    }
+
+
+
+}

--- a/app/src/main/java/com/android/sample/model/auth/SignInRepository.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInRepository.kt
@@ -14,4 +14,6 @@ interface SignInRepository {
       onAuthSuccess: () -> Unit,
       onAuthError: (String) -> Unit
   )
+
+  fun signOut()
 }

--- a/app/src/main/java/com/android/sample/model/auth/SignInRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInRepositoryFirebase.kt
@@ -51,4 +51,8 @@ constructor(private val auth: FirebaseAuth, private val profilesRepository: Prof
           Log.e("SignInRepository", "Error checking user profile: ${it.message}")
         })
   }
+
+  override fun signOut() {
+    auth.signOut()
+  }
 }

--- a/app/src/main/java/com/android/sample/model/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInViewModel.kt
@@ -64,6 +64,10 @@ constructor(
     }
   }
 
+  fun signOut() {
+    signInRepository.signOut()
+  }
+
   companion object {
     fun Factory(): ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -39,7 +39,7 @@ fun ChooseAccountScreen(
   val userProfile by profileViewModel.userState.collectAsState()
 
   LazyColumn(
-      modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+      modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp).testTag("chooseAccountScreen"),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.Center) {
         // Greeting Text
@@ -49,32 +49,36 @@ fun ChooseAccountScreen(
               fontSize = 24.sp,
               fontWeight = FontWeight.Bold,
               textAlign = TextAlign.Center,
-              modifier = Modifier.padding(bottom = 16.dp),
+              modifier = Modifier.padding(bottom = 16.dp).testTag("greetingText"),
               overflow = TextOverflow.Ellipsis,
               maxLines = 2)
         }
 
         item { Spacer(modifier = Modifier.height(16.dp)) }
+
         // Profile Image
         item {
           ProfileImage(
               url = userProfile?.photo,
               modifier = Modifier.size(100.dp).clip(CircleShape).testTag("profilePicture"))
         }
+
         item { Spacer(modifier = Modifier.height(16.dp)) }
 
+        // Continue as Text (Clickable)
         item {
           Text(
-              text = "Continue as ${userProfile?.name }",
+              text = "Continue as ${userProfile?.name}",
               fontSize = 16.sp,
               color = Color.Blue,
               fontWeight = FontWeight.SemiBold,
-              textDecoration = TextDecoration.Underline, // Underline to indicate clickable text
+              textDecoration = TextDecoration.Underline,
               modifier =
-                  Modifier.padding(vertical = 8.dp).clickable {
-                    navigationActions.navigateTo(Screen.OVERVIEW)
-                  })
+                  Modifier.padding(vertical = 8.dp)
+                      .clickable { navigationActions.navigateTo(Screen.OVERVIEW) }
+                      .testTag("continueText"))
         }
+
         item { Spacer(modifier = Modifier.height(16.dp)) }
 
         // Switch Account Button
@@ -85,7 +89,10 @@ fun ChooseAccountScreen(
                 navigationActions.navigateTo(Screen.AUTH)
               },
               modifier =
-                  Modifier.fillMaxWidth(0.8f).height(48.dp).clip(RoundedCornerShape(12.dp))) {
+                  Modifier.fillMaxWidth(0.8f)
+                      .height(48.dp)
+                      .clip(RoundedCornerShape(12.dp))
+                      .testTag("switchAccountButton")) {
                 Text(
                     text = "Switch Account",
                     fontSize = 16.sp,

--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -1,0 +1,98 @@
+// ChooseAccount.kt
+package com.android.sample.ui.authentication
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.android.sample.model.auth.SignInViewModel
+import com.android.sample.model.profile.ProfileViewModel
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
+import com.android.sample.ui.profile.ProfileImage
+
+@Composable
+fun ChooseAccountScreen(
+    navigationActions: NavigationActions,
+    signInViewModel: SignInViewModel = hiltViewModel(),
+    profileViewModel: ProfileViewModel = hiltViewModel()
+) {
+  // Collect the user profile data from ProfileViewModel
+  val userProfile by profileViewModel.userState.collectAsState()
+
+  LazyColumn(
+      modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
+        // Greeting Text
+        item {
+          Text(
+              text = "Hello ${userProfile?.name ?: "User"}, you are already signed in!",
+              fontSize = 24.sp,
+              fontWeight = FontWeight.Bold,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(bottom = 16.dp),
+              overflow = TextOverflow.Ellipsis,
+              maxLines = 2)
+        }
+
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+        // Profile Image
+        item {
+          ProfileImage(
+              url = userProfile?.photo,
+              modifier = Modifier.size(100.dp).clip(CircleShape).testTag("profilePicture"))
+        }
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+
+        item {
+          Text(
+              text = "Continue as ${userProfile?.name }",
+              fontSize = 16.sp,
+              color = Color.Blue,
+              fontWeight = FontWeight.SemiBold,
+              textDecoration = TextDecoration.Underline, // Underline to indicate clickable text
+              modifier =
+                  Modifier.padding(vertical = 8.dp).clickable {
+                    navigationActions.navigateTo(Screen.OVERVIEW)
+                  })
+        }
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+
+        // Switch Account Button
+        item {
+          Button(
+              onClick = {
+                signInViewModel.signOut()
+                navigationActions.navigateTo(Screen.AUTH)
+              },
+              modifier =
+                  Modifier.fillMaxWidth(0.8f).height(48.dp).clip(RoundedCornerShape(12.dp))) {
+                Text(
+                    text = "Switch Account",
+                    fontSize = 16.sp,
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(vertical = 8.dp))
+              }
+        }
+      }
+}

--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -13,6 +13,7 @@ object Route {
   const val OVERVIEW = "Overview"
   const val PROFILE = "Profile"
   const val ADD_ACTIVITY = "AddActivity"
+  const val CHOOSE_ACCOUNT = "ChooseAccount"
 }
 
 object Screen {
@@ -25,6 +26,7 @@ object Screen {
   const val ACTIVITY_DETAILS = "ActivityDetails Screen"
   const val EDIT_PROFILE = "EditProfile Screen"
   const val CREATE_PROFILE = "CreateProfile Screen"
+  const val CHOOSE_ACCOUNT = "ChooseAccount Screen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.ModeEdit
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -32,6 +35,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,6 +59,8 @@ import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 
 @Composable
 fun ProfileScreen(
@@ -120,6 +128,8 @@ fun ProfileContent(
     navigationActions: NavigationActions,
     listActivitiesViewModel: ListActivitiesViewModel
 ) {
+  var showMenu by remember { mutableStateOf(false) } // To control the visibility of the menu
+
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("profileScreen"),
       bottomBar = {
@@ -139,6 +149,32 @@ fun ProfileContent(
                         imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                         contentDescription = "Back")
                   }
+            },
+            actions = {
+              IconButton(
+                  onClick = { showMenu = true }, modifier = Modifier.testTag("moreOptionsButton")) {
+                    Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = "More options")
+                  }
+
+              // DropdownMenu for options
+              DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                DropdownMenuItem(
+                    text = { Text("Logout") },
+                    onClick = {
+                      showMenu = false
+                      Firebase.auth.signOut()
+                      navigationActions.navigateTo(Screen.AUTH)
+                      // Handle logout action
+                    },
+                    enabled = Firebase.auth.currentUser?.isAnonymous == false)
+
+                DropdownMenuItem(
+                    text = { Text("General Terms") },
+                    onClick = {
+                      showMenu = false
+                      // Handle general terms action
+                    })
+              }
             })
       },
       floatingActionButton = {
@@ -154,7 +190,6 @@ fun ProfileContent(
                 Text(text = "Profile", fontSize = 30.sp, modifier = Modifier.padding(top = 16.dp))
 
                 // Profile Picture
-
                 ProfileImage(
                     url = user.photo,
                     modifier = Modifier.size(100.dp).clip(CircleShape).testTag("profilePicture"))
@@ -186,7 +221,9 @@ fun ProfileContent(
               }
 
               item {
+
                 // Activities Section
+
                 Text(
                     text = "Activities Created",
                     fontSize = 24.sp,
@@ -194,7 +231,9 @@ fun ProfileContent(
                         Modifier.padding(start = 16.dp, top = 16.dp)
                             .testTag("activitiesCreatedTitle"))
               }
+
               // Activities Created
+
               user.activities?.let { activities ->
                 items(activities.size) { index ->
                   ActivityCreatedBox(
@@ -207,6 +246,7 @@ fun ProfileContent(
 
               item { // Activities Enrolled in
                 Spacer(modifier = Modifier.height(16.dp))
+
                 Text(
                     text = "Activities Enrolled in",
                     fontSize = 24.sp,
@@ -214,7 +254,9 @@ fun ProfileContent(
                         Modifier.padding(start = 16.dp, top = 16.dp)
                             .testTag("activitiesEnrolledTitle"))
               }
+
               // Activities Enrolled
+
               user.activities?.let { activities ->
                 items(activities.size) { index ->
                   ActivityEnrolledBox(


### PR DESCRIPTION
This PR introduces a new Choose Account Screen that displays when a user is already logged in. Like in Instagram or Facebook, the screen gives the option to either continue with the current account or switch to a different account.

Key changes include:

- Choose Account Screen: A new screen that appears if the user is already logged in, allowing the user to select their current account or switch accounts.

- Profile Picture Integration: Displays the user's profile picture on the Choose Account Screen.

- Sign-Out Functionality: A  function  in the SignInViewModel, simplifying the process of signing out from different parts of the application.

- Navigation Actions: Updates to the navigation structure to incorporate the new Choose Account Screen.