### PR TITLE
Fix Intermittent Failure in `createButton_isDisabledInitially` Test by Ensuring UI Readiness

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -141,9 +141,19 @@ class CreateActivityScreenTest {
     composeTestRule.setContent {
       CreateActivityScreen(mockViewModel, mockNavigationActions, mockProfileViewModel)
     }
+
+    // Wait for the UI to finish rendering
+    composeTestRule.waitForIdle()
+
+    // Ensure the button is displayed
+    // composeTestRule.onNodeWithTag("createButton").assertIsDisplayed()
+
+    // Scroll to the button to ensure it's in view
     composeTestRule
         .onNodeWithTag("activityCreateScreen")
         .performScrollToNode(hasTestTag("createButton"))
+
+    // Assert that the button is not enabled
     composeTestRule.onNodeWithTag("createButton").assertIsNotEnabled()
   }
 


### PR DESCRIPTION
The `createButton_isDisabledInitially` test was intermittently failing during some CI executions. This test ensures that the "Create" button is initially disabled when the `CreateActivityScreen` is loaded. The failure occurs due to timing issues related to UI rendering or asynchronous data loading.

Changes made:
- Added a `waitForIdle()` to ensure that the UI has finished rendering before the button's state is checked.
  
This update ensures the test reliably verifies that the "Create" button is disabled initially, addressing issues related to timing and rendering delays.

Closes #140