### PR TITLE
Feature/like activity details

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -18,8 +18,10 @@ import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.Comment
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.profile.ProfileViewModel
+import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.model.profile.User
 import com.android.sample.ui.activitydetails.ActivityDetailsScreen
+import com.android.sample.ui.activitydetails.LikeButton
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.Timestamp
@@ -42,14 +44,15 @@ class ActivityDetailsScreenAndroidTest {
   private lateinit var mockProfileViewModel: ProfileViewModel
   private lateinit var testUser: User
   private lateinit var mockFirebaseRepository: ActivitiesRepositoryFirestore
+    private lateinit var mockRepository: ProfilesRepository
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     mockFirebaseRepository = mock(ActivitiesRepositoryFirestore::class.java)
+      mockRepository = mock(ProfilesRepository::class.java)
 
-    mockProfileViewModel = mock(ProfileViewModel::class.java)
 
     mockNavigationActions = mock(NavigationActions::class.java)
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.ACTIVITY_DETAILS)
@@ -63,8 +66,8 @@ class ActivityDetailsScreenAndroidTest {
             interests = listOf("Cycling", "Reading"),
             activities = listOf("Football"))
 
-    val userStateFlow = MutableStateFlow(testUser)
-    `when`(mockProfileViewModel.userState).thenReturn(userStateFlow)
+
+
 
     mockViewModel = mock(ListActivitiesViewModel::class.java)
     activity =
@@ -91,7 +94,9 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun activityComponents_areDisplayed() {
-    composeTestRule.setContent {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+      composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
           navigationActions = mockNavigationActions,
@@ -104,10 +109,14 @@ class ActivityDetailsScreenAndroidTest {
     composeTestRule.onNodeWithTag("price&&location").assertIsDisplayed()
     composeTestRule.onNodeWithTag("schedule").assertIsDisplayed()
     composeTestRule.onNodeWithTag("duration").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
+
   }
 
   @Test
   fun enrollButtonIsDisplayedWhenActivityIsActive() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -122,6 +131,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollButtonIsNotDisplayedWhenActivityIsFinished() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     activity = activity.copy(status = ActivityStatus.FINISHED)
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
     composeTestRule.setContent {
@@ -136,6 +147,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun activityDetailsAreDisplayedCorrectly() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -153,6 +166,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun goBackButtonNavigatesBack() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -166,6 +181,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollButton_displays_whenUserLoggedIn() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -182,6 +199,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun editButton_displaysForActiveActivity_whenUserIsTheCreator() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val activity1 = activity.copy(creator = "123")
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity1))
 
@@ -202,6 +221,9 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun loginRegisterButton_displays_whenUserIsNotLoggedIn() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+
     // Set the user state to null to simulate the user not being logged in
     val userStateFlow = MutableStateFlow<User?>(null)
     `when`(mockProfileViewModel.userState).thenReturn(userStateFlow)
@@ -223,6 +245,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollFailureToast_displays_whenPlacesAreFull() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set placesLeft equal to maxPlaces to simulate full capacity
     activity = activity.copy(placesLeft = activity.maxPlaces)
     val activityStateFlow = MutableStateFlow(activity)
@@ -244,6 +268,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun deleteMainComment_removesMainCommentSuccessfully() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set initial comments with a main comment
     val comments =
         listOf(
@@ -268,6 +294,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun deleteReply_removesReplyFromMainComment() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set initial comments with replies
     val comments =
         listOf(
@@ -301,6 +329,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun replyToComment_displaysNewReplyInList() {
+      mockProfileViewModel = mock(ProfileViewModel::class.java)
+      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val comments =
         listOf(
             activity.comments
@@ -325,4 +355,24 @@ class ActivityDetailsScreenAndroidTest {
     // Assert that the new reply is added
     assert(comments.first().replies.any { it.content == "This is a reply" })
   }
+
+    @Test
+    fun changeIconWhenActivityIsLiked() {
+        mockProfileViewModel = ProfileViewModel(mockRepository)
+
+        composeTestRule.setContent { LikeButton(testUser, activity, mockProfileViewModel) }
+
+        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
+
+        // Click on the like button
+        composeTestRule.onNodeWithTag("likeButtonfalse").performClick()
+
+        // Verify that the like button is toggled
+        composeTestRule.onNodeWithTag("likeButtontrue").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("likeButtontrue").performClick()
+
+        // Verify that the like button is toggled
+        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
+    }
+
 }

--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.activityDetails
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
@@ -44,15 +45,14 @@ class ActivityDetailsScreenAndroidTest {
   private lateinit var mockProfileViewModel: ProfileViewModel
   private lateinit var testUser: User
   private lateinit var mockFirebaseRepository: ActivitiesRepositoryFirestore
-    private lateinit var mockRepository: ProfilesRepository
+  private lateinit var mockRepository: ProfilesRepository
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     mockFirebaseRepository = mock(ActivitiesRepositoryFirestore::class.java)
-      mockRepository = mock(ProfilesRepository::class.java)
-
+    mockRepository = mock(ProfilesRepository::class.java)
 
     mockNavigationActions = mock(NavigationActions::class.java)
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.ACTIVITY_DETAILS)
@@ -65,9 +65,6 @@ class ActivityDetailsScreenAndroidTest {
             photo = "",
             interests = listOf("Cycling", "Reading"),
             activities = listOf("Football"))
-
-
-
 
     mockViewModel = mock(ListActivitiesViewModel::class.java)
     activity =
@@ -94,9 +91,9 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun activityComponents_areDisplayed() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
-      composeTestRule.setContent {
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
           navigationActions = mockNavigationActions,
@@ -109,14 +106,13 @@ class ActivityDetailsScreenAndroidTest {
     composeTestRule.onNodeWithTag("price&&location").assertIsDisplayed()
     composeTestRule.onNodeWithTag("schedule").assertIsDisplayed()
     composeTestRule.onNodeWithTag("duration").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
-
+    composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
   }
 
   @Test
   fun enrollButtonIsDisplayedWhenActivityIsActive() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -131,8 +127,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollButtonIsNotDisplayedWhenActivityIsFinished() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     activity = activity.copy(status = ActivityStatus.FINISHED)
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
     composeTestRule.setContent {
@@ -147,8 +143,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun activityDetailsAreDisplayedCorrectly() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -166,8 +162,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun goBackButtonNavigatesBack() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -181,8 +177,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollButton_displays_whenUserLoggedIn() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -199,8 +195,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun editButton_displaysForActiveActivity_whenUserIsTheCreator() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val activity1 = activity.copy(creator = "123")
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity1))
 
@@ -221,8 +217,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun loginRegisterButton_displays_whenUserIsNotLoggedIn() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
 
     // Set the user state to null to simulate the user not being logged in
     val userStateFlow = MutableStateFlow<User?>(null)
@@ -245,8 +241,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun enrollFailureToast_displays_whenPlacesAreFull() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set placesLeft equal to maxPlaces to simulate full capacity
     activity = activity.copy(placesLeft = activity.maxPlaces)
     val activityStateFlow = MutableStateFlow(activity)
@@ -268,8 +264,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun deleteMainComment_removesMainCommentSuccessfully() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set initial comments with a main comment
     val comments =
         listOf(
@@ -294,8 +290,8 @@ class ActivityDetailsScreenAndroidTest {
 
   @Test
   fun deleteReply_removesReplyFromMainComment() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set initial comments with replies
     val comments =
         listOf(
@@ -326,11 +322,25 @@ class ActivityDetailsScreenAndroidTest {
     // Assert that the reply is removed
     assert(comments.first().replies.none { it.uid == "reply-uid" })
   }
+    @Test
+    fun notLoggedInNoLikeButton(){
+        mockProfileViewModel = mock(ProfileViewModel::class.java)
+        val userStateFlow = MutableStateFlow<User?>(null)
+        `when`(mockProfileViewModel.userState).thenReturn(userStateFlow)
+        composeTestRule.setContent {
+            ActivityDetailsScreen(
+                listActivityViewModel = mockViewModel,
+                navigationActions = mockNavigationActions,
+                profileViewModel = mockProfileViewModel)
+        }
+        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("likeButtontrue").assertIsNotDisplayed()
+    }
 
   @Test
   fun replyToComment_displaysNewReplyInList() {
-      mockProfileViewModel = mock(ProfileViewModel::class.java)
-      `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val comments =
         listOf(
             activity.comments
@@ -356,23 +366,23 @@ class ActivityDetailsScreenAndroidTest {
     assert(comments.first().replies.any { it.content == "This is a reply" })
   }
 
-    @Test
-    fun changeIconWhenActivityIsLiked() {
-        mockProfileViewModel = ProfileViewModel(mockRepository)
 
-        composeTestRule.setContent { LikeButton(testUser, activity, mockProfileViewModel) }
+  @Test
+  fun changeIconWhenActivityIsLiked() {
+    mockProfileViewModel = ProfileViewModel(mockRepository)
 
-        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
+    composeTestRule.setContent { LikeButton(testUser, activity, mockProfileViewModel) }
 
-        // Click on the like button
-        composeTestRule.onNodeWithTag("likeButtonfalse").performClick()
+    composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
 
-        // Verify that the like button is toggled
-        composeTestRule.onNodeWithTag("likeButtontrue").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("likeButtontrue").performClick()
+    // Click on the like button
+    composeTestRule.onNodeWithTag("likeButtonfalse").performClick()
 
-        // Verify that the like button is toggled
-        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
-    }
+    // Verify that the like button is toggled
+    composeTestRule.onNodeWithTag("likeButtontrue").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("likeButtontrue").performClick()
 
+    // Verify that the like button is toggled
+    composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -322,20 +322,21 @@ class ActivityDetailsScreenAndroidTest {
     // Assert that the reply is removed
     assert(comments.first().replies.none { it.uid == "reply-uid" })
   }
-    @Test
-    fun notLoggedInNoLikeButton(){
-        mockProfileViewModel = mock(ProfileViewModel::class.java)
-        val userStateFlow = MutableStateFlow<User?>(null)
-        `when`(mockProfileViewModel.userState).thenReturn(userStateFlow)
-        composeTestRule.setContent {
-            ActivityDetailsScreen(
-                listActivityViewModel = mockViewModel,
-                navigationActions = mockNavigationActions,
-                profileViewModel = mockProfileViewModel)
-        }
-        composeTestRule.onNodeWithTag("likeButtonfalse").assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag("likeButtontrue").assertIsNotDisplayed()
+
+  @Test
+  fun notLoggedInNoLikeButton() {
+    mockProfileViewModel = mock(ProfileViewModel::class.java)
+    val userStateFlow = MutableStateFlow<User?>(null)
+    `when`(mockProfileViewModel.userState).thenReturn(userStateFlow)
+    composeTestRule.setContent {
+      ActivityDetailsScreen(
+          listActivityViewModel = mockViewModel,
+          navigationActions = mockNavigationActions,
+          profileViewModel = mockProfileViewModel)
     }
+    composeTestRule.onNodeWithTag("likeButtonfalse").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("likeButtontrue").assertIsNotDisplayed()
+  }
 
   @Test
   fun replyToComment_displaysNewReplyInList() {
@@ -365,7 +366,6 @@ class ActivityDetailsScreenAndroidTest {
     // Assert that the new reply is added
     assert(comments.first().replies.any { it.content == "This is a reply" })
   }
-
 
   @Test
   fun changeIconWhenActivityIsLiked() {

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -47,10 +49,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ActivityStatus
 import com.android.sample.model.activity.Comment
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.profile.ProfileViewModel
+import com.android.sample.model.profile.User
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.Timestamp
@@ -159,7 +163,9 @@ fun ActivityDetailsScreen(
                         text = "Activity Image",
                         color = Color.White,
                         modifier = Modifier.align(Alignment.Center))
-                  }
+                  LikeButton(profile, activity, profileViewModel)
+
+              }
 
               // Title
               Box(
@@ -490,3 +496,33 @@ fun CommentItem(
     }
   }
 }
+@Composable
+fun LikeButton(profile: User?, activity: Activity?, profileViewModel: ProfileViewModel) {
+    var isLiked by remember {
+        mutableStateOf(activity?.let { profile?.likedActivities?.contains(it.uid) } ?: false)
+    }
+
+    if (profile != null) {
+        IconButton(
+            modifier = Modifier.testTag("likeButton$isLiked"),
+            onClick = {
+                isLiked = !isLiked
+                if (isLiked) {
+                    if (activity != null) {
+                        profileViewModel.addLikedActivity(profile.id, activity.uid)
+                    }
+                } else {
+                    if (activity != null) {
+                        profileViewModel.removeLikedActivity(profile.id, activity.uid)
+                    }
+                }
+            },
+        ) {
+            Icon(
+                imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                contentDescription = if (isLiked) "Liked" else "Not Liked",
+                tint = if (isLiked) Color.Black else Color.LightGray)
+        }
+    }
+}
+

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -163,9 +163,8 @@ fun ActivityDetailsScreen(
                         text = "Activity Image",
                         color = Color.White,
                         modifier = Modifier.align(Alignment.Center))
-                  LikeButton(profile, activity, profileViewModel)
-
-              }
+                    LikeButton(profile, activity, profileViewModel)
+                  }
 
               // Title
               Box(
@@ -496,33 +495,33 @@ fun CommentItem(
     }
   }
 }
+
 @Composable
 fun LikeButton(profile: User?, activity: Activity?, profileViewModel: ProfileViewModel) {
-    var isLiked by remember {
-        mutableStateOf(activity?.let { profile?.likedActivities?.contains(it.uid) } ?: false)
-    }
+  var isLiked by remember {
+    mutableStateOf(activity?.let { profile?.likedActivities?.contains(it.uid) } ?: false)
+  }
 
-    if (profile != null) {
-        IconButton(
-            modifier = Modifier.testTag("likeButton$isLiked"),
-            onClick = {
-                isLiked = !isLiked
-                if (isLiked) {
-                    if (activity != null) {
-                        profileViewModel.addLikedActivity(profile.id, activity.uid)
-                    }
-                } else {
-                    if (activity != null) {
-                        profileViewModel.removeLikedActivity(profile.id, activity.uid)
-                    }
-                }
-            },
-        ) {
-            Icon(
-                imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-                contentDescription = if (isLiked) "Liked" else "Not Liked",
-                tint = if (isLiked) Color.Black else Color.LightGray)
-        }
+  if (profile != null) {
+    IconButton(
+        modifier = Modifier.testTag("likeButton$isLiked"),
+        onClick = {
+          isLiked = !isLiked
+          if (isLiked) {
+            if (activity != null) {
+              profileViewModel.addLikedActivity(profile.id, activity.uid)
+            }
+          } else {
+            if (activity != null) {
+              profileViewModel.removeLikedActivity(profile.id, activity.uid)
+            }
+          }
+        },
+    ) {
+      Icon(
+          imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+          contentDescription = if (isLiked) "Liked" else "Not Liked",
+          tint = if (isLiked) Color.Black else Color.LightGray)
     }
+  }
 }
-


### PR DESCRIPTION
# feat: Add Like Button in Activity Details

## Summary
This pull request introduces a "Like" feature to the activity details screen, allowing users to like or unlike an activity directly from its details view. This functionality enhances the user experience by making it easier to interact with activities individually.

## Features
- **Like Button on Activity Details Screen**:
  - A "like" button now appears on the activity image in the activity details screen.
  - The heart icon displays as:
    - **Black** when the activity is liked by the user.
    - **Gray** when the activity is disliked by the user or has not been liked.

- **Conditional Display**:
  - The like button is only displayed if the user is logged in, ensuring proper functionality and user experience based on login status.

## Testing
The following test cases have been added to ensure the correct behavior of the like button:

- **Like Button State**:
  - Verifies that the heart icon is black if the user has liked the activity.
  - Ensures the icon displays as gray when the activity is unliked.
  
- **Login Condition**:
  - Ensures that the like button is not displayed if the user is not logged in.



close #112 
