### PR TITLE
Fix (profile creation): no profile creation without name and surname

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
@@ -108,6 +108,8 @@ class ProfileCreationTest {
     // Verify that the navigation action was called with the correct route
     // Simulate successful profile creation when called
     // composeTestRule.onNodeWithTag("createProfileButton").performScrollTo()
+    composeTestRule.onNodeWithTag("nameTextField").performTextInput("John")
+    composeTestRule.onNodeWithTag("surnameTextField").performTextInput("Doe")
     composeTestRule
         .onNodeWithTag("profileCreationScrollColumn")
         .performScrollToNode(hasTestTag("createProfileButton"))
@@ -127,6 +129,8 @@ class ProfileCreationTest {
     }
 
     // Perform the click action
+    composeTestRule.onNodeWithTag("nameTextField").performTextInput("John")
+    composeTestRule.onNodeWithTag("surnameTextField").performTextInput("Doe")
     composeTestRule
         .onNodeWithTag("profileCreationScrollColumn")
         .performScrollToNode(hasTestTag("createProfileButton"))

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -1,5 +1,8 @@
 package com.android.sample.resources
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
 // Like R, but C
 object C {
   object Tag {
@@ -9,5 +12,10 @@ object C {
 
     const val main_screen_container = "main_screen_container"
     const val second_screen_container = "second_screen_container"
+
+    // for textfields
+    val ERROR_TEXTFIELD_PADDING_START = 16.dp
+    val ERROR_TEXTFIELD_PADDING_TOP = 5.dp
+    val ERROR_TEXTFIELD_FONT_SIZE = 12.sp
   }
 }

--- a/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
@@ -82,7 +82,7 @@ fun SignInScreen(navigationActions: NavigationActions, viewModel: SignInViewMode
                     if (input.isBlank()) "Password cannot be empty" else null
                   },
                   externalError = passwordErrorState.value,
-                  errorTestTag = "PasswordError")
+                  errorTestTag = "PasswordErrorText")
 
               Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.sp
 import com.android.sample.R
 import com.android.sample.model.auth.SignInViewModel
 import com.android.sample.ui.components.EmailTextField
-import com.android.sample.ui.components.PasswordTextField
+import com.android.sample.ui.components.TextFieldWithErrorState
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -42,7 +42,6 @@ fun SignInScreen(navigationActions: NavigationActions, viewModel: SignInViewMode
   val passwordState = remember { mutableStateOf("") }
   val passwordErrorState = remember { mutableStateOf<String?>(null) }
   val token = stringResource(R.string.default_web_client_id)
-  val isPasswordVisible = remember { mutableStateOf(false) }
   val onAuthSuccess = { Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show() }
 
   val onAuthError = { errorMessage: String ->
@@ -74,43 +73,32 @@ fun SignInScreen(navigationActions: NavigationActions, viewModel: SignInViewMode
                   emailError = null)
               Spacer(modifier = Modifier.height(16.dp))
 
-              // Password Input
-              PasswordTextField(
-                  password = passwordState.value,
-                  onPasswordChange = { passwordState.value = it },
-                  isPasswordVisible = isPasswordVisible.value,
-                  onPasswordVisibilityChange = {
-                    isPasswordVisible.value = !isPasswordVisible.value
+              TextFieldWithErrorState(
+                  value = passwordState.value,
+                  onValueChange = { passwordState.value = it },
+                  label = "Password",
+                  modifier = Modifier.fillMaxWidth(0.8f).testTag("PasswordTextField"),
+                  validation = { input ->
+                    if (input.isBlank()) "Password cannot be empty" else null
                   },
-              )
-
-              // Password Error
-              passwordErrorState.value?.let {
-                Text(
-                    text = it,
-                    color = Color.Red,
-                    fontSize = 12.sp,
-                    modifier =
-                        Modifier.align(Alignment.Start)
-                            .padding(start = 40.dp)
-                            .testTag("PasswordErrorText"))
-              }
+                  externalError = passwordErrorState.value,
+                  errorTestTag = "PasswordError")
 
               Spacer(modifier = Modifier.height(16.dp))
 
               // Sign-In Button
               Button(
                   onClick = {
-                    when {
-                      passwordState.value.isEmpty() ->
-                          passwordErrorState.value = "Password cannot be empty"
-                      else ->
-                          viewModel.signInWithEmailAndPassword(
-                              emailState.value,
-                              passwordState.value,
-                              onAuthSuccess,
-                              onAuthError,
-                              navigationActions)
+                    if (passwordState.value.isEmpty()) {
+                      passwordErrorState.value = "Password cannot be empty" // Set external error
+                    } else {
+                      passwordErrorState.value = null // Clear external error if password is valid
+                      viewModel.signInWithEmailAndPassword(
+                          emailState.value,
+                          passwordState.value,
+                          onAuthSuccess,
+                          onAuthError,
+                          navigationActions)
                     }
                     Log.d("SignInScreen", "Sign in with email/password")
                   },

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -7,6 +8,11 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -14,6 +20,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_START
+import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_TOP
 
 @Composable
 fun PasswordTextField(
@@ -54,5 +62,43 @@ fun EmailTextField(
       modifier = Modifier.fillMaxWidth(0.8f).testTag("EmailTextField"))
   emailError?.let {
     Text(text = it, color = Color.Red, fontSize = 12.sp, modifier = Modifier.padding(start = 16.dp))
+  }
+}
+
+@Composable
+fun TextFieldWithErrorState(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    validation: (String) -> String?,
+    externalError: String? = null,
+    errorTestTag: String
+) {
+  var internalError by remember { mutableStateOf<String?>(null) }
+
+  // Show external error if present, otherwise use internal error
+  val error = externalError ?: internalError
+
+  Column() {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { newValue ->
+          onValueChange(newValue)
+          internalError = validation(newValue)
+        },
+        label = { Text(label) },
+        isError = error != null,
+        modifier = modifier)
+    error?.let {
+      Text(
+          text = it,
+          color = Color.Red,
+          fontSize = 12.sp,
+          modifier =
+              Modifier.align(Alignment.Start)
+                  .padding(start = ERROR_TEXTFIELD_PADDING_START, top = ERROR_TEXTFIELD_PADDING_TOP)
+                  .testTag(errorTestTag))
+    }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_FONT_SIZE
 import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_START
 import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_TOP
 
@@ -94,7 +95,7 @@ fun TextFieldWithErrorState(
       Text(
           text = it,
           color = Color.Red,
-          fontSize = 12.sp,
+          fontSize = ERROR_TEXTFIELD_FONT_SIZE,
           modifier =
               Modifier.align(Alignment.Start)
                   .padding(start = ERROR_TEXTFIELD_PADDING_START, top = ERROR_TEXTFIELD_PADDING_TOP)


### PR DESCRIPTION
In this PR:
- I added the TextFieldWithErrorState composable, a reusable component designed for input validation with error handling. 
- I fixed the issue of being able to create a profile without a name and a surname using this new component
- I used the new component in the sign in
- I updated some old tests where I was clicking on the "create profile" button without filling the name and the surname