### PR TITLE
fix: reset profile data on logout to prevent residual user information

### DIFF
--- a/app/src/main/java/com/android/sample/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/profile/ProfileViewModel.kt
@@ -29,6 +29,7 @@ open class ProfileViewModel @Inject constructor(private val repository: Profiles
         fetchUserData(currentUser.uid)
       } else {
         Log.d("ProfileViewModel", "No user is authenticated, skipping data fetch.")
+        clearUserData()
       }
     }
   }
@@ -38,6 +39,10 @@ open class ProfileViewModel @Inject constructor(private val repository: Profiles
         userId,
         onSuccess = { userState_.value = it },
         onFailure = { Log.e("error", " not fetching") })
+  }
+
+  fun clearUserData() {
+    userState_.value = null
   }
 
   fun createUserProfile(userProfile: User, onSuccess: () -> Unit, onError: (Exception) -> Unit) {

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -72,7 +72,8 @@ fun ProfileScreen(
   when (val profile = profileState.value) {
     null -> LoadingScreen(navigationActions) // Show a loading indicator or a retry button
     else -> {
-      ProfileContent(user = profile, navigationActions, listActivitiesViewModel)
+      ProfileContent(
+          user = profile, navigationActions, listActivitiesViewModel, userProfileViewModel)
     }
   // Proceed with showing profile content
   }
@@ -123,7 +124,8 @@ fun LoadingScreen(navigationActions: NavigationActions) {
 fun ProfileContent(
     user: User,
     navigationActions: NavigationActions,
-    listActivitiesViewModel: ListActivitiesViewModel
+    listActivitiesViewModel: ListActivitiesViewModel,
+    userProfileViewModel: ProfileViewModel
 ) {
   var showMenu by remember { mutableStateOf(false) } // To control the visibility of the menu
   Log.d("ProfileScreen", "User photo: ${user.photo}")
@@ -159,18 +161,12 @@ fun ProfileContent(
                     text = { Text("Logout") },
                     onClick = {
                       showMenu = false
+                      userProfileViewModel.clearUserData()
                       Firebase.auth.signOut()
                       navigationActions.navigateTo(Screen.AUTH)
                       // Handle logout action
                     },
                     enabled = Firebase.auth.currentUser?.isAnonymous == false)
-
-                DropdownMenuItem(
-                    text = { Text("General Terms") },
-                    onClick = {
-                      showMenu = false
-                      // Handle general terms action
-                    })
               }
             })
       },


### PR DESCRIPTION
In this PR, I just added a new function in the profileViewModel and called it in the profileScreen, you can see the details in my commit messages.
### How to try this new fix:
1. Log-in with you account or with Google
2. Go to the profile screen 
3. Click on the "..." dots on the top right corner and then click on "Logout"
4. Log-in as a Guest and go to the profile screen
5. Now you should not have the previous profile showing
