### PR TITLE
Disable line break create and edit activity

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -157,8 +157,7 @@ fun CreateActivityScreen(
                 onValueChange = { title = it },
                 label = { Text("Title") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputTitleCreate"),
-                placeholder = { Text(text = stringResource(id = R.string.request_activity_title))
-                              },
+                placeholder = { Text(text = stringResource(id = R.string.request_activity_title)) },
                 singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
@@ -170,8 +169,7 @@ fun CreateActivityScreen(
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputDescriptionCreate"),
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_activity_description))
-                }
-            )
+                })
             Spacer(modifier = Modifier.height(8.dp))
 
             OutlinedTextField(

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -157,7 +157,9 @@ fun CreateActivityScreen(
                 onValueChange = { title = it },
                 label = { Text("Title") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputTitleCreate"),
-                placeholder = { Text(text = stringResource(id = R.string.request_activity_title)) },
+                placeholder = { Text(text = stringResource(id = R.string.request_activity_title))
+                              },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -168,7 +170,7 @@ fun CreateActivityScreen(
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputDescriptionCreate"),
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_activity_description))
-                },
+                }
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -180,6 +182,7 @@ fun CreateActivityScreen(
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_date_activity_withFormat))
                 },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -189,6 +192,7 @@ fun CreateActivityScreen(
                 label = { Text("Time") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth(),
                 placeholder = { Text(text = stringResource(id = R.string.hour_min_format)) },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -198,6 +202,7 @@ fun CreateActivityScreen(
                 label = { Text("Duration") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth(),
                 placeholder = { Text(text = stringResource(id = R.string.hour_min_format)) },
+                singleLine = true,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -208,6 +213,7 @@ fun CreateActivityScreen(
                 label = { Text("Price") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputPriceCreate"),
                 placeholder = { Text(text = stringResource(id = R.string.request_price_activity)) },
+                singleLine = true,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -219,6 +225,7 @@ fun CreateActivityScreen(
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_placesMax_activity))
                 },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -182,6 +182,7 @@ fun EditActivityScreen(
                 label = { Text("Title") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputTitleEdit"),
                 placeholder = { Text(text = stringResource(id = R.string.request_activity_title)) },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
             OutlinedTextField(
@@ -202,6 +203,7 @@ fun EditActivityScreen(
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_date_activity_withFormat))
                 },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -211,6 +213,7 @@ fun EditActivityScreen(
                 label = { Text("Time") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth(),
                 placeholder = { Text(text = stringResource(id = R.string.hour_min_format)) },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
@@ -220,6 +223,7 @@ fun EditActivityScreen(
                 label = { Text("Duration") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth(),
                 placeholder = { Text(text = stringResource(id = R.string.hour_min_format)) },
+                singleLine = true,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -230,6 +234,7 @@ fun EditActivityScreen(
                 label = { Text("Price") },
                 modifier = Modifier.padding(8.dp).fillMaxWidth().testTag("inputPriceEdit"),
                 placeholder = { Text(text = stringResource(id = R.string.request_price_activity)) },
+                singleLine = true,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -241,6 +246,7 @@ fun EditActivityScreen(
                 placeholder = {
                   Text(text = stringResource(id = R.string.request_placesMax_activity))
                 },
+                singleLine = true,
             )
             Spacer(modifier = Modifier.height(8.dp))
             ExposedDropdownMenuBox(


### PR DESCRIPTION
## Disallow multiple lines in text fields in create and edit activity


 * When creating or editing an activity, only allow multiple lines for description
 * All the other text fields have a single line
 * This is for a better UX

### Remarks:
- There are no tests since I only modified the attributes of the text fields.
- The original issue was only about making these changes in Create Activity, but for more coherence, I also made the same changes is Edit Activity.