### PR TITLE
Restructure/restructure tests dummy data

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -14,9 +14,6 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.model.activity.ActivitiesRepository
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.activity.types
 import com.android.sample.model.map.Location
@@ -26,9 +23,7 @@ import com.android.sample.model.map.LocationViewModel
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Timestamp
 import io.mockk.mockk
-import java.util.GregorianCalendar
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -53,24 +48,6 @@ class CreateActivityScreenTest {
   private val location2 = Location(46.5, 6.6, "Lausanne")
   private val locationList = listOf(location, location2)
   private val locationListFlow = MutableStateFlow(listOf(location, location2))
-
-  private val activity =
-      Activity(
-          "1",
-          "First Activity",
-          "Do something",
-          creator = "John Doe",
-          date = Timestamp(GregorianCalendar(2024, 8, 5).time),
-          location = location,
-          status = ActivityStatus.ACTIVE,
-          participants = listOf(),
-          price = 10.0,
-          placesLeft = 10,
-          maxPlaces = 20,
-          images = listOf(),
-          type = ActivityType.PRO,
-          startTime = "09:30",
-          duration = "00:30")
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/com/android/sample/ui/activity/EditActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/EditActivityScreenTest.kt
@@ -12,18 +12,15 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.model.activity.ActivitiesRepository
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.map.Location
 import com.android.sample.model.map.LocationPermissionChecker
 import com.android.sample.model.map.LocationRepository
 import com.android.sample.model.map.LocationViewModel
+import com.android.sample.resources.dummydata.activity
+import com.android.sample.resources.dummydata.locationList
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Timestamp
-import java.util.GregorianCalendar
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -42,29 +39,7 @@ class EditActivityScreenTest {
   private lateinit var mockLocationViewModel: LocationViewModel
   private lateinit var mockPermissionChecker: LocationPermissionChecker
 
-  private val location = Location(46.519962, 6.633597, "EPFL")
-  private val location2 = Location(46.5, 6.6, "Lausanne")
-  private val locationList = listOf(location, location2)
-
   @get:Rule val composeTestRule = createComposeRule()
-
-  private val activity =
-      Activity(
-          "1",
-          "First Activity",
-          "Do something",
-          creator = "John Doe",
-          date = Timestamp(GregorianCalendar(2024, 8, 5).time),
-          location = location,
-          status = ActivityStatus.ACTIVE,
-          participants = listOf(),
-          price = 10.0,
-          placesLeft = 10,
-          maxPlaces = 20,
-          images = listOf(),
-          type = ActivityType.PRO,
-          startTime = "09:30",
-          duration = "00:30")
 
   @Before
   fun setUp() {
@@ -219,7 +194,6 @@ class EditActivityScreenTest {
     composeTestRule.onNodeWithTag("nameTextFieldUser").performTextInput("John")
     composeTestRule.onNodeWithTag("surnameTextFieldUser").performTextInput("Doe")
     composeTestRule.onNodeWithTag("addUserButton").performClick()
-    // composeTestRule.onNodeWithTag("attendeeRow0").assertIsDisplayed()
     composeTestRule.onNodeWithTag("attendeeName0").assertTextEquals("John Doe")
   }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/activity/LikedActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/LikedActivitiesTest.kt
@@ -6,20 +6,17 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.android.sample.model.activity.ActivitiesRepository
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
-import com.android.sample.model.map.Location
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.ProfilesRepository
-import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.activity
+import com.android.sample.resources.dummydata.activityBiking
+import com.android.sample.resources.dummydata.testUser
 import com.android.sample.ui.listActivities.ActivityCard2
 import com.android.sample.ui.listActivities.LikedActivitiesScreen
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Timestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -36,25 +33,6 @@ class LikedActivitiesTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var viewModel: ListActivitiesViewModel
   private lateinit var profileViewModel: ProfileViewModel
-  private lateinit var testUser: User
-
-  private val testActivity =
-      Activity(
-          uid = "1",
-          title = "Mountain Biking",
-          description = "Exciting mountain biking experience.",
-          date = Timestamp.now(),
-          location = Location(46.519962, 6.633597, "EPFL"),
-          creator = "Chris",
-          images = listOf(),
-          price = 10.0,
-          status = ActivityStatus.ACTIVE,
-          type = ActivityType.PRO,
-          placesLeft = 8,
-          maxPlaces = 15,
-          participants = listOf(),
-          duration = "2 hours",
-          startTime = "10:00")
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -66,15 +44,6 @@ class LikedActivitiesTest {
     navigationActions = mock(NavigationActions::class.java)
     viewModel = ListActivitiesViewModel(activitiesRepository)
 
-    testUser =
-        User(
-            id = "Rola",
-            name = "Amine",
-            surname = "A",
-            photo = "",
-            interests = listOf("Cycling", "Reading"),
-            activities = listOf(),
-            likedActivities = listOf(testActivity.uid))
     // val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)
 
@@ -106,8 +75,8 @@ class LikedActivitiesTest {
   fun whenNoLikedActivities_thenDisplaysEmptyMessage() {
     profileViewModel = mock(ProfileViewModel::class.java)
     // Set liked activities to empty to simulate no liked activities
-    testUser = testUser.copy(likedActivities = emptyList())
-    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    val emptyTestUser = testUser.copy(likedActivities = emptyList())
+    whenever(profileViewModel.userState).thenReturn(MutableStateFlow(emptyTestUser))
 
     composeTestRule.setContent {
       LikedActivitiesScreen(viewModel, navigationActions, profileViewModel)
@@ -122,12 +91,12 @@ class LikedActivitiesTest {
     profileViewModel = mock(ProfileViewModel::class.java)
     composeTestRule.setContent {
       ActivityCard2(
-          activityId = testActivity.uid,
+          activityId = activityBiking.uid,
           navigationActions = navigationActions,
           listActivitiesViewModel = viewModel,
           profileViewModel = profileViewModel,
           profile = testUser,
-          allActivities = listOf(testActivity))
+          allActivities = listOf(activityBiking))
     }
     composeTestRule.onNodeWithTag("activityCard").assertIsDisplayed()
     composeTestRule.onNodeWithText("Mountain Biking").assertIsDisplayed()
@@ -141,12 +110,12 @@ class LikedActivitiesTest {
     profileViewModel = mock(ProfileViewModel::class.java)
     composeTestRule.setContent {
       ActivityCard2(
-          activityId = testActivity.uid,
+          activityId = activityBiking.uid,
           navigationActions = navigationActions,
           listActivitiesViewModel = viewModel,
           profileViewModel = profileViewModel,
           profile = testUser,
-          allActivities = listOf(testActivity))
+          allActivities = listOf(activityBiking))
     }
     composeTestRule.onNodeWithTag("activityCard").assertIsDisplayed()
     composeTestRule.onNodeWithText("Mountain Biking").assertIsDisplayed()
@@ -161,12 +130,12 @@ class LikedActivitiesTest {
     profileViewModel = ProfileViewModel(profilesRepository)
     composeTestRule.setContent {
       ActivityCard2(
-          activityId = testActivity.uid,
+          activityId = activityBiking.uid,
           navigationActions = navigationActions,
           listActivitiesViewModel = viewModel,
           profileViewModel = profileViewModel,
           profile = testUser,
-          allActivities = listOf(testActivity))
+          allActivities = listOf(activityBiking))
     }
 
     // Verify initial state is liked
@@ -190,12 +159,12 @@ class LikedActivitiesTest {
     profileViewModel = ProfileViewModel(profilesRepository)
     composeTestRule.setContent {
       ActivityCard2(
-          activityId = testActivity.uid,
+          activityId = activity.uid,
           navigationActions = navigationActions,
           listActivitiesViewModel = viewModel,
           profileViewModel = profileViewModel,
           profile = testUser,
-          allActivities = listOf(testActivity))
+          allActivities = listOf(activity))
     }
     composeTestRule.onNodeWithTag("activityCard").performClick()
     verify(navigationActions).navigateTo(Screen.ACTIVITY_DETAILS)

--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -13,22 +13,19 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.sample.model.activity.ActivitiesRepositoryFirestore
-import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.Comment
 import com.android.sample.model.activity.ListActivitiesViewModel
-import com.android.sample.model.map.Location
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.activityWithParticipants
+import com.android.sample.resources.dummydata.testUser
 import com.android.sample.ui.activitydetails.ActivityDetailsScreen
 import com.android.sample.ui.activitydetails.LikeButton
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.Timestamp
-import java.util.Calendar
-import java.util.GregorianCalendar
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -43,10 +40,8 @@ class ActivityDetailsScreenAndroidTest {
   private lateinit var mockNavigationActions: NavigationActions
 
   private lateinit var mockViewModel: ListActivitiesViewModel
-  private lateinit var activity: Activity
 
   private lateinit var mockProfileViewModel: ProfileViewModel
-  private lateinit var testUser: User
   private lateinit var mockFirebaseRepository: ActivitiesRepositoryFirestore
   private lateinit var mockRepository: ProfilesRepository
 
@@ -60,52 +55,9 @@ class ActivityDetailsScreenAndroidTest {
     mockNavigationActions = mock(NavigationActions::class.java)
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.ACTIVITY_DETAILS)
 
-    testUser =
-        User(
-            id = "123",
-            name = "Amine",
-            surname = "A",
-            photo = "",
-            interests = listOf("Cycling", "Reading"),
-            activities = listOf("Football"))
-
     mockViewModel = mock(ListActivitiesViewModel::class.java)
-    activity =
-        Activity(
-            uid = "123",
-            title = "Sample Activity",
-            description = "Sample Description",
-            date = Timestamp(GregorianCalendar(2025, Calendar.NOVEMBER, 3).time),
-            price = 10.0,
-            placesLeft = 5,
-            maxPlaces = 10,
-            creator = "Creator",
-            status = ActivityStatus.ACTIVE,
-            location = Location(46.519962, 6.633597, "EPFL"),
-            images = listOf("1"),
-            participants =
-                listOf(
-                    User(
-                        id = "1",
-                        name = "Amine",
-                        surname = "A",
-                        interests = listOf("Cycling"),
-                        activities = listOf(),
-                        photo = "",
-                        likedActivities = listOf("1")),
-                    User(
-                        id = "2",
-                        name = "John",
-                        surname = "Doe",
-                        interests = listOf("Reading"),
-                        activities = listOf(),
-                        photo = "",
-                        likedActivities = listOf("1"))),
-            duration = "02:00",
-            startTime = "10:00",
-            type = ActivityType.INDIVIDUAL,
-            comments = listOf())
-    val activityStateFlow = MutableStateFlow(activity)
+
+    val activityStateFlow = MutableStateFlow(activityWithParticipants)
     `when`(mockViewModel.selectedActivity).thenReturn(activityStateFlow)
   }
 
@@ -149,8 +101,8 @@ class ActivityDetailsScreenAndroidTest {
   fun enrollButtonIsNotDisplayedWhenActivityIsFinished() {
     mockProfileViewModel = mock(ProfileViewModel::class.java)
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
-    activity = activity.copy(status = ActivityStatus.FINISHED)
-    `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
+    val activityFinished = activityWithParticipants.copy(status = ActivityStatus.FINISHED)
+    `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activityFinished))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -216,8 +168,8 @@ class ActivityDetailsScreenAndroidTest {
   @Test
   fun editButton_displaysForActiveActivity_whenUserIsTheCreator() {
     mockProfileViewModel = mock(ProfileViewModel::class.java)
-    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
-    val activity1 = activity.copy(creator = "123")
+    `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser.copy(id = "123")))
+    val activity1 = activityWithParticipants.copy(creator = "123")
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity1))
 
     composeTestRule.setContent {
@@ -264,8 +216,9 @@ class ActivityDetailsScreenAndroidTest {
     mockProfileViewModel = mock(ProfileViewModel::class.java)
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set placesLeft equal to maxPlaces to simulate full capacity
-    activity = activity.copy(placesLeft = activity.maxPlaces)
-    val activityStateFlow = MutableStateFlow(activity)
+    val activityWithMaxParticipants =
+        activityWithParticipants.copy(placesLeft = activityWithParticipants.maxPlaces)
+    val activityStateFlow = MutableStateFlow(activityWithMaxParticipants)
     `when`(mockViewModel.selectedActivity).thenReturn(activityStateFlow)
 
     composeTestRule.setContent {
@@ -289,7 +242,7 @@ class ActivityDetailsScreenAndroidTest {
     // Set initial comments with a main comment
     val comments =
         listOf(
-            activity.comments
+            activityWithParticipants.comments
                 .firstOrNull()
                 ?.copy(uid = "main-comment-uid", content = "Main comment") ?: return)
 
@@ -315,7 +268,7 @@ class ActivityDetailsScreenAndroidTest {
     // Set initial comments with replies
     val comments =
         listOf(
-            activity.comments
+            activityWithParticipants.comments
                 .firstOrNull()
                 ?.copy(
                     uid = "main-comment-uid",
@@ -364,7 +317,7 @@ class ActivityDetailsScreenAndroidTest {
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val comments =
         listOf(
-            activity.comments
+            activityWithParticipants.comments
                 .firstOrNull()
                 ?.copy(uid = "main-comment-uid", content = "Main comment", replies = listOf())
                 ?: return)
@@ -405,14 +358,16 @@ class ActivityDetailsScreenAndroidTest {
     // composeTestRule.onNodeWithTag("participants").assertIsDisplayed()
 
     // Check if each participant's name is displayed
-    activity.participants.forEach { participant ->
+    activityWithParticipants.participants.forEach { participant ->
       composeTestRule.onNodeWithText(participant.name).assertIsDisplayed()
     }
 
     fun changeIconWhenActivityIsLiked() {
       mockProfileViewModel = ProfileViewModel(mockRepository)
 
-      composeTestRule.setContent { LikeButton(testUser, activity, mockProfileViewModel) }
+      composeTestRule.setContent {
+        LikeButton(testUser, activityWithParticipants, mockProfileViewModel)
+      }
 
       composeTestRule.onNodeWithTag("likeButtonfalse").assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/CommentItemTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/CommentItemTest.kt
@@ -9,12 +9,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.model.activity.Comment
+import com.android.sample.resources.dummydata.testComment
+import com.android.sample.resources.dummydata.timestamp
 import com.android.sample.ui.activitydetails.CommentItem
 import com.android.sample.ui.activitydetails.CommentSection
-import com.google.firebase.Timestamp
-import java.util.UUID
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,28 +21,7 @@ import org.junit.runner.RunWith
 class CommentItemTest {
   @get:Rule val composeTestRule = createComposeRule()
 
-  private lateinit var testComment: Comment
   private val testProfileId = "123"
-  val timestamp = Timestamp.now()
-
-  @Before
-  fun setUp() {
-    testComment =
-        Comment(
-            uid = UUID.randomUUID().toString(),
-            userId = "123",
-            userName = "Amine",
-            content = "This is a comment",
-            timestamp = timestamp,
-            replies =
-                listOf(
-                    Comment(
-                        uid = UUID.randomUUID().toString(),
-                        userId = "124",
-                        userName = "John",
-                        content = "This is a reply",
-                        timestamp = timestamp)))
-  }
 
   @Test
   fun commentItem_displaysCommentCorrectly() {

--- a/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/ChooseAccountScreenTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.performClick
 import com.android.sample.model.auth.SignInRepository
 import com.android.sample.model.auth.SignInViewModel
 import com.android.sample.model.profile.ProfileViewModel
-import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.userProfile
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,14 +40,6 @@ class ChooseAccountScreenTest {
   @Test
   fun allElementsAreDisplayed() {
     // Setup a default mock user profile
-    val userProfile =
-        User(
-            name = "John Doe",
-            photo = "https://example.com/photo.jpg",
-            interests = listOf(),
-            surname = "Doe",
-            id = "123",
-            activities = listOf())
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
 
     // Set the content once for this test
@@ -66,14 +58,6 @@ class ChooseAccountScreenTest {
   @Test
   fun displaysGreetingTextAndProfileImage_whenUserProfileIsNotNull() {
     // Setup the mock user profile with a non-null user
-    val userProfile =
-        User(
-            name = "John Doe",
-            photo = "https://example.com/photo.jpg",
-            interests = listOf(),
-            surname = "Doe",
-            id = "123",
-            activities = listOf())
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
 
     // Set the content once for this test
@@ -103,14 +87,7 @@ class ChooseAccountScreenTest {
   @Test
   fun clickableContinueText_navigatesToOverview() {
     // Setup a default mock user profile
-    val userProfile =
-        User(
-            name = "John Doe",
-            photo = "https://example.com/photo.jpg",
-            interests = listOf(),
-            surname = "Doe",
-            id = "123",
-            activities = listOf())
+
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
 
     // Set the content once for this test
@@ -127,14 +104,7 @@ class ChooseAccountScreenTest {
   @Test
   fun displaysPlaceholder_whenProfileImageUrlIsEmpty() {
     // Setup the mock user profile with an empty photo URL
-    val userProfile =
-        User(
-            name = "John Doe",
-            photo = "",
-            interests = listOf(),
-            surname = "Doe",
-            id = "123",
-            activities = listOf())
+
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(userProfile))
 
     // Set the content once for this test

--- a/app/src/androidTest/java/com/android/sample/ui/authentication/TextFieldsTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/TextFieldsTest.kt
@@ -3,6 +3,7 @@ package com.android.sample.ui.authentication
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.android.sample.resources.dummydata.password
 import com.android.sample.ui.components.PasswordTextField
 import org.junit.Rule
 import org.junit.Test
@@ -30,7 +31,6 @@ class TextFieldsTest {
 
   @Test
   fun testPasswordVisibilityToggle() {
-    val password = "testPassword"
     val isPasswordVisible = mutableStateOf(false)
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/AddUserDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/AddUserDialogTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.emptyUser
+import com.android.sample.resources.dummydata.simpleUser
 import org.junit.Rule
 import org.junit.Test
 
@@ -30,16 +32,7 @@ class AddUserDialogTest {
     composeTestRule.onNodeWithTag("surnameTextFieldUser").performTextInput("Doe")
     composeTestRule.onNodeWithTag("addUserButton").performClick()
 
-    assert(
-        userAdded ==
-            User(
-                id = "",
-                name = "John",
-                surname = "Doe",
-                interests = listOf(),
-                activities = listOf(),
-                photo = null,
-                likedActivities = listOf()))
+    assert(userAdded == simpleUser)
   }
 
   @Test
@@ -59,16 +52,7 @@ class AddUserDialogTest {
 
     composeTestRule.onNodeWithTag("addUserButton").performClick()
 
-    assert(
-        userAdded ==
-            User(
-                id = "",
-                name = "",
-                surname = "",
-                interests = listOf(),
-                activities = listOf(),
-                photo = null,
-                likedActivities = listOf()))
+    assert(userAdded == emptyUser)
   }
 
   @Test
@@ -80,15 +64,6 @@ class AddUserDialogTest {
     composeTestRule.onNodeWithTag("surnameTextFieldUser").performTextInput("Doe")
     composeTestRule.onNodeWithTag("addUserButton").performClick()
 
-    assert(
-        userAdded ==
-            User(
-                id = "",
-                name = "John",
-                surname = "Doe",
-                interests = listOf(),
-                activities = listOf(),
-                photo = null,
-                likedActivities = listOf()))
+    assert(userAdded == simpleUser)
   }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
@@ -7,17 +7,13 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
 import com.android.sample.model.activity.ActivitiesRepository
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
-import com.android.sample.model.map.Location
 import com.android.sample.model.map.LocationPermissionChecker
 import com.android.sample.model.map.LocationRepository
 import com.android.sample.model.map.LocationViewModel
+import com.android.sample.resources.dummydata.activity
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Timestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -63,24 +59,6 @@ class MapScreenTest {
       MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
     }
   }
-
-  private val activity =
-      Activity(
-          uid = "1",
-          title = "Mountain Biking",
-          description = "Exciting mountain biking experience.",
-          date = Timestamp.now(),
-          location = Location(46.519962, 6.633597, "EPFL"),
-          creator = "Chris",
-          images = listOf(),
-          price = 10.0,
-          status = ActivityStatus.ACTIVE,
-          type = ActivityType.PRO,
-          placesLeft = 8,
-          maxPlaces = 15,
-          participants = listOf(),
-          duration = "2 hours",
-          startTime = "10:00")
 
   @Test
   fun testMapScreenIsDisplayed() {

--- a/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
@@ -8,9 +8,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.profile.ProfileViewModel
-import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.testUser
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen.PROFILE
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,24 +24,15 @@ import org.mockito.kotlin.mock
 @RunWith(AndroidJUnit4::class)
 class EditProfileScreenTest {
   private lateinit var profileViewModel: ProfileViewModel
-  private lateinit var profile: User
   private lateinit var navigationActions: NavigationActions
-  private lateinit var listActivitiesViewModel: ListActivitiesViewModel
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
 
     profileViewModel = mock<ProfileViewModel>()
-    profile =
-        User(
-            id = "123",
-            name = "Amine",
-            surname = "A",
-            photo = "",
-            interests = listOf("Cycling", "Reading"),
-            activities = listOf("Football"))
-    val userStateFlow = MutableStateFlow(profile)
+
+    val userStateFlow = MutableStateFlow(testUser)
     navigationActions = Mockito.mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(PROFILE)
     `when`(profileViewModel.userState).thenReturn(userStateFlow)

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performTextInput
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.testUserId
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.auth.FirebaseAuth
@@ -33,9 +34,6 @@ class ProfileCreationTest {
   // private val mockProfilesRepository: ProfilesRepository = mock()
   @get:Rule val composeTestRule = createComposeRule()
 
-  // Define a test user ID
-  private val testUserId = "testUser123"
-
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
@@ -46,7 +44,7 @@ class ProfileCreationTest {
     val mockFirebaseAuth = mock(FirebaseAuth::class.java)
     val mockFirebaseUser = mock(FirebaseUser::class.java)
     `when`(mockFirebaseAuth.currentUser).thenReturn(mockFirebaseUser)
-    `when`(mockFirebaseUser.uid).thenReturn("testUser123")
+    `when`(mockFirebaseUser.uid).thenReturn(testUserId)
 
     profileViewModel = ProfileViewModel(repository = mockProfilesRepository)
 

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -9,15 +9,13 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.sample.model.activity.ActivitiesRepository
 import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
-import com.android.sample.model.map.Location
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.activityList
+import com.android.sample.resources.dummydata.listOfActivitiesUid
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
-import com.google.firebase.Timestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
@@ -31,8 +29,6 @@ class ProfileScreenTest {
 
   private lateinit var userProfileViewModel: ProfileViewModel
   private lateinit var testUser: User
-  private lateinit var activity1: Activity
-  private lateinit var activity2: Activity
   private lateinit var navigationActions: NavigationActions
   private lateinit var listActivitiesViewModel: ListActivitiesViewModel
   private lateinit var activitiesRepository: ActivitiesRepository
@@ -44,44 +40,9 @@ class ProfileScreenTest {
     activitiesRepository = mock(ActivitiesRepository::class.java)
     userProfileViewModel = mock(ProfileViewModel::class.java)
     listActivitiesViewModel = ListActivitiesViewModel(activitiesRepository)
-    activity1 =
-        Activity(
-            uid = "3",
-            title = "Fun Farm",
-            description = "Come discover the new farm and enjoy with your family!",
-            date = Timestamp.now(),
-            location = Location(46.5, 6.6, "Lausanne"),
-            creator = "Rola",
-            price = 1.0,
-            images = listOf(),
-            placesLeft = 10,
-            maxPlaces = 20,
-            status = ActivityStatus.ACTIVE,
-            type = ActivityType.PRO,
-            participants = listOf(),
-            duration = "2 hours",
-            startTime = "10:00",
-        )
-    activity2 =
-        Activity(
-            uid = "2",
-            title = "Cooking",
-            description = "Great cooking class",
-            date = Timestamp.now(),
-            location = Location(46.519962, 6.633597, "EPFL"),
-            creator = "123",
-            price = 1.0,
-            images = listOf(),
-            placesLeft = 10,
-            maxPlaces = 20,
-            status = ActivityStatus.ACTIVE,
-            type = ActivityType.PRO,
-            participants = listOf(),
-            duration = "2 hours",
-            startTime = "10:00",
-        )
+
     `when`(activitiesRepository.getActivities(any(), any())).then {
-      it.getArgument<(List<Activity>) -> Unit>(0)(listOf(activity1, activity2))
+      it.getArgument<(List<Activity>) -> Unit>(0)(activityList)
     }
 
     listActivitiesViewModel.getActivities()
@@ -92,7 +53,7 @@ class ProfileScreenTest {
             surname = "A",
             photo = "",
             interests = listOf("Cycling", "Reading"),
-            activities = listOf(activity1.uid, activity2.uid),
+            activities = listOfActivitiesUid,
         )
     val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)

--- a/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
@@ -1,0 +1,213 @@
+package com.android.sample.resources.dummydata
+
+import com.android.sample.model.activity.Activity
+import com.android.sample.model.activity.ActivityStatus
+import com.android.sample.model.activity.ActivityType
+import com.android.sample.model.activity.Comment
+import com.android.sample.model.map.Location
+import com.android.sample.model.profile.User
+import com.google.firebase.Timestamp
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.UUID
+
+val timestamp = Timestamp.now()
+val location = Location(46.519962, 6.633597, "EPFL")
+val location2 = Location(46.5, 6.6, "Lausanne")
+val locationList = listOf(location, location2)
+val activity =
+    Activity(
+        "1",
+        "First Activity",
+        "Do something",
+        creator = "John Doe",
+        date = Timestamp(GregorianCalendar(2024, 8, 5).time),
+        location = location,
+        status = ActivityStatus.ACTIVE,
+        participants = listOf(),
+        price = 10.0,
+        placesLeft = 10,
+        maxPlaces = 20,
+        images = listOf(),
+        type = ActivityType.PRO,
+        startTime = "09:30",
+        duration = "00:30")
+
+val testComment =
+    Comment(
+        uid = UUID.randomUUID().toString(),
+        userId = "123",
+        userName = "Amine",
+        content = "This is a comment",
+        timestamp = timestamp,
+        replies =
+            listOf(
+                Comment(
+                    uid = UUID.randomUUID().toString(),
+                    userId = "124",
+                    userName = "John",
+                    content = "This is a reply",
+                    timestamp = timestamp)))
+val userProfile =
+    User(
+        name = "John Doe",
+        photo = "https://example.com/photo.jpg",
+        interests = listOf(),
+        surname = "Doe",
+        id = "123",
+        activities = listOf())
+
+const val password = "testPassword"
+
+val activityWithParticipants =
+    Activity(
+        uid = "123",
+        title = "Sample Activity",
+        description = "Sample Description",
+        date = Timestamp(GregorianCalendar(2025, Calendar.NOVEMBER, 3).time),
+        price = 10.0,
+        placesLeft = 5,
+        maxPlaces = 10,
+        creator = "Creator",
+        status = ActivityStatus.ACTIVE,
+        location = Location(46.519962, 6.633597, "EPFL"),
+        images = listOf("1"),
+        participants =
+            listOf(
+                User(
+                    id = "1",
+                    name = "Amine",
+                    surname = "A",
+                    interests = listOf("Cycling"),
+                    activities = listOf(),
+                    photo = "",
+                    likedActivities = listOf("1")),
+                User(
+                    id = "2",
+                    name = "John",
+                    surname = "Doe",
+                    interests = listOf("Reading"),
+                    activities = listOf(),
+                    photo = "",
+                    likedActivities = listOf("1"))),
+        duration = "02:00",
+        startTime = "10:00",
+        type = ActivityType.INDIVIDUAL,
+        comments = listOf())
+
+val simpleUser =
+    User(
+        id = "",
+        name = "John",
+        surname = "Doe",
+        interests = listOf(),
+        activities = listOf(),
+        photo = null,
+        likedActivities = listOf())
+
+val emptyUser =
+    User(
+        id = "",
+        name = "",
+        surname = "",
+        interests = listOf(),
+        activities = listOf(),
+        photo = null,
+        likedActivities = listOf())
+
+val activityBiking =
+    Activity(
+        uid = "1",
+        title = "Mountain Biking",
+        description = "Exciting mountain biking experience.",
+        date = Timestamp.now(),
+        location = Location(46.519962, 6.633597, "EPFL"),
+        creator = "Chris",
+        images = listOf(),
+        price = 10.0,
+        status = ActivityStatus.ACTIVE,
+        type = ActivityType.PRO,
+        placesLeft = 8,
+        maxPlaces = 15,
+        participants =
+            listOf(
+                User(
+                    id = "1",
+                    name = "Amine",
+                    surname = "A",
+                    interests = listOf("Cycling"),
+                    activities = listOf(),
+                    photo = "",
+                    likedActivities = listOf("1")),
+                User(
+                    id = "2",
+                    name = "John",
+                    surname = "Doe",
+                    interests = listOf("Reading"),
+                    activities = listOf(),
+                    photo = "",
+                    likedActivities = listOf("1"))),
+        duration = "2 hours",
+        startTime = "10:00")
+
+val testUserId = "testUser123"
+val listOfActivitiesUid = listOf("3", "2")
+
+val activity1 =
+    Activity(
+        uid = "3",
+        title = "Fun Farm",
+        description = "Come discover the new farm and enjoy with your family!",
+        date = Timestamp.now(),
+        location = Location(46.5, 6.6, "Lausanne"),
+        creator = "Rola",
+        price = 1.0,
+        images = listOf(),
+        placesLeft = 10,
+        maxPlaces = 20,
+        status = ActivityStatus.ACTIVE,
+        type = ActivityType.PRO,
+        participants = listOf(),
+        duration = "2 hours",
+        startTime = "10:00",
+    )
+val activity2 =
+    Activity(
+        uid = "2",
+        title = "Cooking",
+        description = "Great cooking class",
+        date = Timestamp.now(),
+        location = Location(46.519962, 6.633597, "EPFL"),
+        creator = "123",
+        price = 1.0,
+        images = listOf(),
+        placesLeft = 10,
+        maxPlaces = 20,
+        status = ActivityStatus.ACTIVE,
+        type = ActivityType.PRO,
+        participants = listOf(),
+        duration = "2 hours",
+        startTime = "10:00",
+    )
+
+val activityList = listOf(activity1, activity2)
+
+val testUser =
+    User(
+        id = "Rola",
+        name = "Amine",
+        surname = "A",
+        photo = "",
+        interests = listOf("Cycling", "Reading"),
+        activities = listOf(),
+        likedActivities = listOf(activityBiking.uid))
+
+val userWithActivities =
+    User(
+        id = "Rola",
+        name = "Amine",
+        surname = "A",
+        photo = "",
+        interests = listOf("Cycling", "Reading"),
+        activities = listOf(),
+        likedActivities = listOf(activityBiking.uid))

--- a/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
@@ -211,3 +211,7 @@ val userWithActivities =
         interests = listOf("Cycling", "Reading"),
         activities = listOf(),
         likedActivities = listOf(activityBiking.uid))
+
+const val email = "test@example.com"
+const val idToken = "testGoogleIdToken"
+val uid = "testUid"

--- a/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
@@ -3,13 +3,9 @@ package com.android.sample.model.activities
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.model.activity.ActivitiesRepositoryFirestore
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
-import com.android.sample.model.map.Location
+import com.android.sample.resources.dummydata.activityBiking
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
-import com.google.firebase.Timestamp
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
@@ -40,24 +36,7 @@ class ActivitiesRepositoryFirestoreTest {
 
   private lateinit var activitiesRepositoryFirestore: ActivitiesRepositoryFirestore
 
-  private val activity =
-      Activity(
-          title = "FOOTBALL",
-          uid = "1",
-          status = ActivityStatus.ACTIVE,
-          location = Location(46.519962, 6.633597, "EPFL"),
-          date = Timestamp.now(),
-          creator = "me",
-          description = "Do something",
-          placesLeft = 5,
-          maxPlaces = 10,
-          participants = listOf(),
-          images = listOf(),
-          price = 0.0,
-          startTime = "09:30",
-          duration = "00:30",
-          type = ActivityType.PRO,
-      )
+  private val activity = activityBiking
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/android/sample/model/activities/ListActivitiesViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/activities/ListActivitiesViewModelTest.kt
@@ -2,11 +2,9 @@ package com.android.sample.model.activities
 
 import com.android.sample.model.activity.ActivitiesRepository
 import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.map.Location
-import com.google.firebase.Timestamp
+import com.android.sample.resources.dummydata.activityBiking
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
@@ -28,24 +26,7 @@ class ListActivitiesViewModelTest {
   private lateinit var listActivitiesViewModel: ListActivitiesViewModel
 
   private val location = Location(46.519962, 6.633597, "EPFL")
-  private val activity =
-      Activity(
-          title = "FOOTBALL",
-          uid = "1",
-          status = ActivityStatus.ACTIVE,
-          location = location,
-          date = Timestamp.now(),
-          creator = "me",
-          description = "Do something",
-          placesLeft = 0,
-          maxPlaces = 0,
-          participants = listOf(),
-          images = listOf(),
-          price = 0.0,
-          startTime = "09:30",
-          duration = "00:30",
-          type = ActivityType.PRO,
-      )
+  private val activity = activityBiking
 
   @Before
   fun setUp() {
@@ -55,8 +36,8 @@ class ListActivitiesViewModelTest {
 
   @Test
   fun getNewUid() {
-    `when`(activitiesRepository.getNewUid()).thenReturn("uid")
-    assertThat(listActivitiesViewModel.getNewUid(), `is`("uid"))
+    `when`(activitiesRepository.getNewUid()).thenReturn("1")
+    assertThat(listActivitiesViewModel.getNewUid(), `is`("1"))
   }
 
   @Test

--- a/app/src/test/java/com/android/sample/model/auth/SignInRepositoryFirebaseTest.kt
+++ b/app/src/test/java/com/android/sample/model/auth/SignInRepositoryFirebaseTest.kt
@@ -3,6 +3,10 @@ package com.android.sample.model.auth
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.model.profile.ProfilesRepositoryFirestore
 import com.android.sample.model.profile.User
+import com.android.sample.resources.dummydata.email
+import com.android.sample.resources.dummydata.idToken
+import com.android.sample.resources.dummydata.password
+import com.android.sample.resources.dummydata.uid
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.android.gms.tasks.Tasks
@@ -48,8 +52,6 @@ class SignInRepositoryFirebaseTest {
   @Test
   fun `signInWithEmail should return AuthResult on success`() = runBlocking {
     // Given
-    val email = "test@example.com"
-    val password = "password123"
     val mockAuthResult = mock(AuthResult::class.java)
 
     // Mock the Task<AuthResult> returned by signInWithEmailAndPassword
@@ -67,8 +69,6 @@ class SignInRepositoryFirebaseTest {
   @Test(expected = Exception::class)
   fun `signInWithEmail should throw exception on failure`(): Unit = runBlocking {
     // Given
-    val email = "test@example.com"
-    val password = "password123"
 
     // Mock the Task<AuthResult> to return an exception
     val mockTask = Tasks.forException<AuthResult>(Exception("Firebase sign-in failed"))
@@ -111,7 +111,6 @@ class SignInRepositoryFirebaseTest {
   @Test(expected = Exception::class)
   fun `signInWithGoogle should throw exception on failure`(): Unit = runBlocking {
     // Given
-    val idToken = "testGoogleIdToken"
 
     // Create the mock credential
     val mockCredential = GoogleAuthProvider.getCredential(idToken, null)
@@ -139,7 +138,6 @@ class SignInRepositoryFirebaseTest {
   @Test
   fun `checkUserProfile should navigate to create profile if user profile is not found`() =
       runTest {
-        val uid = "testUid"
         // Mock getUser to return null (no profile found)
         `when`(profilesRepository.getUser(anyOrNull(), anyOrNull(), anyOrNull())).thenAnswer {
           println("Simulating getUser callback with null profile")
@@ -158,7 +156,6 @@ class SignInRepositoryFirebaseTest {
 
   @Test
   fun `checkUserProfile should navigate to overview if user profile is found`() = runTest {
-    val uid = "testUid"
     val mockUserProfile = mock(User::class.java)
 
     // Mock getUser to return a user profile
@@ -177,7 +174,6 @@ class SignInRepositoryFirebaseTest {
 
   @Test
   fun `checkUserProfile should call onAuthError if getUser fails`() = runTest {
-    val uid = "testUid"
     // Mock getUser to throw an exception
     `when`(profilesRepository.getUser(eq(uid), anyOrNull(), anyOrNull())).thenAnswer { invocation ->
       val onFailure = invocation.arguments[2] as (Exception) -> Unit

--- a/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
@@ -1,12 +1,9 @@
 package com.android.sample.model.profile
 
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
-import com.android.sample.model.map.Location
+import com.android.sample.resources.dummydata.activity
+import com.android.sample.resources.dummydata.testUser
 import com.google.firebase.FirebaseApp
-import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import org.junit.Before
@@ -27,33 +24,6 @@ class ProfileViewModelTest {
   private lateinit var profilesRepository: ProfilesRepositoryFirestore
   private lateinit var firebaseFirestore: FirebaseFirestore
 
-  private val user =
-      User(
-          id = "1",
-          name = "John",
-          surname = "Doe",
-          photo = "urlToPhoto",
-          interests = listOf("Reading", "Hiking"),
-          activities = listOf("Activity1", "Activity2"))
-
-  private val activity =
-      Activity(
-          title = "FOOTBALL",
-          uid = "1",
-          status = ActivityStatus.ACTIVE,
-          location = Location(46.519962, 6.633597, "EPFL"),
-          date = Timestamp.now(),
-          creator = "me",
-          description = "Do something",
-          placesLeft = 0,
-          maxPlaces = 0,
-          participants = listOf(),
-          images = listOf(),
-          duration = "00:30",
-          startTime = "09:00",
-          type = ActivityType.PRO,
-          price = 0.0)
-
   @Before
   fun setUp() {
 
@@ -68,13 +38,13 @@ class ProfileViewModelTest {
 
   @Test
   fun getActivitiesCallsRepository() {
-    profileViewModel.fetchUserData(user.id)
+    profileViewModel.fetchUserData(testUser.id)
     verify(profilesRepository).getUser(any(), any(), any())
   }
 
   @Test
   fun addActivitiesCallsRepository() {
-    profileViewModel.addActivity(activity.uid, user.id)
+    profileViewModel.addActivity(activity.uid, testUser.id)
     verify(profilesRepository).addActivity(eq(activity.uid), any(), any(), any())
   }
 
@@ -86,17 +56,17 @@ class ProfileViewModelTest {
     // Assuming `getUser` is called with three parameters: userId, onSuccess, onFailure
     // Using `eq` for specific values and `any` for generics where the actual instance doesn't
     // matter for the test
-    profileViewModel.fetchUserData(user.id)
+    profileViewModel.fetchUserData(testUser.id)
 
     // Correct the usage by ensuring all parameters use matchers:
-    verify(profilesRepository).getUser(eq(user.id), any(), any())
+    verify(profilesRepository).getUser(eq(testUser.id), any(), any())
   }
 
   @Test
   fun updateActivitiesCallsRepository() {
     // This should be an operation that triggers updateProfile
-    profileViewModel.updateProfile(user)
-    verify(profilesRepository).updateProfile(eq(user), any(), any())
+    profileViewModel.updateProfile(testUser)
+    verify(profilesRepository).updateProfile(eq(testUser), any(), any())
   }
 
   @Test
@@ -104,10 +74,10 @@ class ProfileViewModelTest {
     val onSuccess = mock<() -> Unit>()
     val onError = mock<(Exception) -> Unit>()
 
-    profileViewModel.createUserProfile(user, onSuccess, onError)
+    profileViewModel.createUserProfile(testUser, onSuccess, onError)
 
     // Verify that the repository's addProfileToDatabase method is called with the correct user
-    verify(profilesRepository).addProfileToDatabase(eq(user), any(), any())
+    verify(profilesRepository).addProfileToDatabase(eq(testUser), any(), any())
   }
 
   @Test
@@ -116,12 +86,12 @@ class ProfileViewModelTest {
     val onError = mock<(Exception) -> Unit>()
 
     // Configure the repository mock to trigger the onSuccess callback
-    `when`(profilesRepository.addProfileToDatabase(eq(user), any(), any())).thenAnswer {
+    `when`(profilesRepository.addProfileToDatabase(eq(testUser), any(), any())).thenAnswer {
       val successCallback = it.getArgument<() -> Unit>(1)
       successCallback()
     }
 
-    profileViewModel.createUserProfile(user, onSuccess, onError)
+    profileViewModel.createUserProfile(testUser, onSuccess, onError)
 
     // Verify that onSuccess callback is triggered
     verify(onSuccess).invoke()
@@ -134,12 +104,12 @@ class ProfileViewModelTest {
     val exception = Exception("Database error")
 
     // Configure the repository mock to trigger the onError callback
-    `when`(profilesRepository.addProfileToDatabase(eq(user), any(), any())).thenAnswer {
+    `when`(profilesRepository.addProfileToDatabase(eq(testUser), any(), any())).thenAnswer {
       val errorCallback = it.getArgument<(Exception) -> Unit>(2)
       errorCallback(exception)
     }
 
-    profileViewModel.createUserProfile(user, onSuccess, onError)
+    profileViewModel.createUserProfile(testUser, onSuccess, onError)
 
     // Verify that onError callback is triggered with the correct exception
     verify(onError).invoke(eq(exception))
@@ -148,32 +118,15 @@ class ProfileViewModelTest {
   @Test
   fun addLikedActivity() {
     // Set up user with the activity in likedActivities
-    val user =
-        User(
-            id = "1",
-            name = "John",
-            surname = "Doe",
-            photo = "urlToPhoto",
-            interests = listOf("Reading", "Hiking"),
-            activities = emptyList(),
-            likedActivities = emptyList())
-    profileViewModel.addLikedActivity(user.id, activity.uid)
-    verify(profilesRepository).addLikedActivity(eq(user.id), eq(activity.uid), any(), any())
+
+    profileViewModel.addLikedActivity(testUser.id, activity.uid)
+    verify(profilesRepository).addLikedActivity(eq(testUser.id), eq(activity.uid), any(), any())
   }
 
   @Test
   fun removeLikedActivity() {
     // Set up user with the activity in likedActivities
-    val user =
-        User(
-            id = "1",
-            name = "John",
-            surname = "Doe",
-            photo = "urlToPhoto",
-            interests = listOf("Reading", "Hiking"),
-            activities = emptyList(),
-            likedActivities = listOf(activity.uid))
-    profileViewModel.removeLikedActivity(user.id, activity.uid)
-    verify(profilesRepository).removeLikedActivity(eq(user.id), eq(activity.uid), any(), any())
+    profileViewModel.removeLikedActivity(testUser.id, activity.uid)
+    verify(profilesRepository).removeLikedActivity(eq(testUser.id), eq(activity.uid), any(), any())
   }
 }

--- a/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
@@ -1,12 +1,8 @@
 package com.android.sample.model.profile
 
-import com.android.sample.model.activity.Activity
-import com.android.sample.model.activity.ActivityStatus
-import com.android.sample.model.activity.ActivityType
-import com.android.sample.model.map.Location
+import com.android.sample.resources.dummydata.testUser
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
-import com.google.firebase.Timestamp
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
@@ -32,33 +28,6 @@ class ProfilesRepositoryFirestoreTest {
 
   private lateinit var profileRepositoryFirestore: ProfilesRepositoryFirestore
 
-  private val activity =
-      Activity(
-          title = "FOOTBALL",
-          uid = "1",
-          status = ActivityStatus.ACTIVE,
-          location = Location(46.519962, 6.633597, "EPFL"),
-          date = Timestamp.now(),
-          creator = "me",
-          description = "Do something",
-          placesLeft = 0,
-          maxPlaces = 0,
-          participants = listOf(),
-          images = listOf(),
-          duration = "00:30",
-          startTime = "09:00",
-          type = ActivityType.PRO,
-          price = 0.0)
-
-  private val user =
-      User(
-          id = "1",
-          name = "John",
-          surname = "Doe",
-          photo = "urlToPhoto",
-          interests = listOf("Reading", "Hiking"),
-          activities = listOf("Activity1", "Activity2"))
-
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
@@ -76,15 +45,7 @@ class ProfilesRepositoryFirestoreTest {
   fun getUser_callsDocumentss() {
     `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
     `when`(mockDocumentSnapshot.exists()).thenReturn(true)
-    `when`(mockDocumentSnapshot.toObject(User::class.java))
-        .thenReturn(
-            User(
-                id = "1",
-                name = "John",
-                surname = "Doe",
-                interests = listOf("Reading", "Hiking"),
-                activities = listOf("Activity1", "Activity2"),
-                photo = "urlToPhoto"))
+    `when`(mockDocumentSnapshot.toObject(User::class.java)).thenReturn(testUser)
 
     profileRepositoryFirestore.getUser(
         "1", onSuccess = {}, onFailure = { fail("Failure callback should not be called") })
@@ -94,29 +55,21 @@ class ProfilesRepositoryFirestoreTest {
 
   @Test
   fun updateProfile_shouldCallFirestoreCollection() {
-    val user =
-        User(
-            id = "1",
-            name = "John",
-            surname = "Doe",
-            interests = listOf("Reading", "Hiking"),
-            activities = listOf("Activity1", "Activity2"),
-            photo = "urlToPhoto")
 
-    `when`(mockDocumentReference.set(user)).thenReturn(Tasks.forResult(null))
+    `when`(mockDocumentReference.set(testUser)).thenReturn(Tasks.forResult(null))
 
-    profileRepositoryFirestore.updateProfile(user, onSuccess = {}, onFailure = {})
+    profileRepositoryFirestore.updateProfile(testUser, onSuccess = {}, onFailure = {})
 
-    verify(mockDocumentReference).set(user)
+    verify(mockDocumentReference).set(testUser)
   }
 
   @Test
   fun updateProfile_shouldCallFirestoreCollectionn() {
     val mockTaskVoid: Task<Void> = Tasks.forResult(null)
-    `when`(mockDocumentReference.set(user)).thenReturn(mockTaskVoid)
+    `when`(mockDocumentReference.set(testUser)).thenReturn(mockTaskVoid)
 
-    profileRepositoryFirestore.updateProfile(user, onSuccess = {}, onFailure = {})
+    profileRepositoryFirestore.updateProfile(testUser, onSuccess = {}, onFailure = {})
 
-    verify(mockDocumentReference).set(user)
+    verify(mockDocumentReference).set(testUser)
   }
 }


### PR DESCRIPTION
In this PR I implemented the use of dummy data following these steps:

- I first created a file named DummyData where I store the data for the tests 
- Secondly I adapted the AndroidTests to use the data stored in DummyData
- And finally modified the unit tests to use the data stored in DummyData

By that, now we can use the same data for tests and cleans up the code