### PR TITLE
Selected activity not updated

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -326,8 +326,9 @@ fun ActivityEnrolledBox(
                   .padding(8.dp)
                   .clip(RoundedCornerShape(16.dp))
                   .clickable {
-                      listActivitiesViewModel.selectActivity(thisActivity)
-                      navigationActions.navigateTo(Screen.ACTIVITY_DETAILS) },
+                    listActivitiesViewModel.selectActivity(thisActivity)
+                    navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
+                  },
           verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painter = painterResource(id = R.drawable.foot),

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -325,7 +325,9 @@ fun ActivityEnrolledBox(
                   .testTag("activityEnrolled")
                   .padding(8.dp)
                   .clip(RoundedCornerShape(16.dp))
-                  .clickable { navigationActions.navigateTo(Screen.ACTIVITY_DETAILS) },
+                  .clickable {
+                      listActivitiesViewModel.selectActivity(thisActivity)
+                      navigationActions.navigateTo(Screen.ACTIVITY_DETAILS) },
           verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painter = painterResource(id = R.drawable.foot),


### PR DESCRIPTION
### Select the activity when click on an enrolled activity in profile sreen

  * select the activity clicked on before navigating to its details screen
  * before the fix: the correct activity was not selected,
  resulting on the navigation to another activity details



