### PR TITLE
Fix: switch the two buttons to switch account and to continue with logged account

### DIFF
--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -64,27 +64,7 @@ fun ChooseAccountScreen(
         }
 
         item { Spacer(modifier = Modifier.height(16.dp)) }
-
-        // Continue as Text (Clickable)
-        item {
-          Text(
-              text = "Switch Account",
-              fontSize = 16.sp,
-              color = Color.Blue,
-              fontWeight = FontWeight.SemiBold,
-              textDecoration = TextDecoration.Underline,
-              modifier =
-                  Modifier.padding(vertical = 8.dp)
-                      .clickable {
-                        signInViewModel.signOut()
-                        navigationActions.navigateTo(Screen.AUTH)
-                      }
-                      .testTag("switchAccountButton"))
-        }
-
-        item { Spacer(modifier = Modifier.height(16.dp)) }
-
-        // Switch Account Button
+        // Continue Button
         item {
           Button(
               onClick = { navigationActions.navigateTo(Screen.OVERVIEW) },
@@ -100,6 +80,25 @@ fun ChooseAccountScreen(
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.padding(vertical = 8.dp))
               }
+        }
+
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+
+        // Switch Account Button
+        item {
+          Text(
+              text = "Switch Account",
+              fontSize = 16.sp,
+              color = Color.Blue,
+              fontWeight = FontWeight.SemiBold,
+              textDecoration = TextDecoration.Underline,
+              modifier =
+                  Modifier.padding(vertical = 8.dp)
+                      .clickable {
+                        signInViewModel.signOut()
+                        navigationActions.navigateTo(Screen.AUTH)
+                      }
+                      .testTag("switchAccountButton"))
         }
       }
 }

--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -68,15 +68,18 @@ fun ChooseAccountScreen(
         // Continue as Text (Clickable)
         item {
           Text(
-              text = "Continue as ${userProfile?.name}",
+              text = "Switch Account",
               fontSize = 16.sp,
               color = Color.Blue,
               fontWeight = FontWeight.SemiBold,
               textDecoration = TextDecoration.Underline,
               modifier =
                   Modifier.padding(vertical = 8.dp)
-                      .clickable { navigationActions.navigateTo(Screen.OVERVIEW) }
-                      .testTag("continueText"))
+                      .clickable {
+                        signInViewModel.signOut()
+                        navigationActions.navigateTo(Screen.AUTH)
+                      }
+                      .testTag("switchAccountButton"))
         }
 
         item { Spacer(modifier = Modifier.height(16.dp)) }
@@ -84,17 +87,14 @@ fun ChooseAccountScreen(
         // Switch Account Button
         item {
           Button(
-              onClick = {
-                signInViewModel.signOut()
-                navigationActions.navigateTo(Screen.AUTH)
-              },
+              onClick = { navigationActions.navigateTo(Screen.OVERVIEW) },
               modifier =
                   Modifier.fillMaxWidth(0.8f)
                       .height(48.dp)
                       .clip(RoundedCornerShape(12.dp))
-                      .testTag("switchAccountButton")) {
+                      .testTag("continueText")) {
                 Text(
-                    text = "Switch Account",
+                    text = "Continue as ${userProfile?.name}",
                     fontSize = 16.sp,
                     color = Color.White,
                     fontWeight = FontWeight.SemiBold,


### PR DESCRIPTION
In this PR:
- I just changed the order of the two buttons
- I made the bigger button be for continuing and the smaller for switching account