### PR TITLE
Fix/invalid time

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -381,7 +381,9 @@ fun CreateActivityScreen(
                 enabled = title.isNotEmpty() && description.isNotEmpty() && dueDate.isNotEmpty(),
                 onClick = {
                   val timeFormat = startTime.split(":")
-                  if (timeFormat.size != 2) {
+                  val timePattern = Regex("^([01]?[0-9]|2[0-3]):[0-5][0-9]$")
+
+                  if (timeFormat.size != 2 || !timePattern.matches(startTime)) {
                     Toast.makeText(
                             context, "Invalid format, time must be HH:MM.", Toast.LENGTH_SHORT)
                         .show()
@@ -394,7 +396,7 @@ fun CreateActivityScreen(
                   }
                   val calendar = GregorianCalendar()
                   val parts = dueDate.split("/")
-                  if (parts.size == 3 && timeFormat.size == 2 && durationFormat.size == 2) {
+                  if (parts.size == 3 && timeFormat.size == 2 && durationFormat.size == 2 && timePattern.matches(startTime)) {
                     attendees += profileViewModel.userState.value!!
                     try {
                       calendar.set(

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -396,7 +396,10 @@ fun CreateActivityScreen(
                   }
                   val calendar = GregorianCalendar()
                   val parts = dueDate.split("/")
-                  if (parts.size == 3 && timeFormat.size == 2 && durationFormat.size == 2 && timePattern.matches(startTime)) {
+                  if (parts.size == 3 &&
+                      timeFormat.size == 2 &&
+                      durationFormat.size == 2 &&
+                      timePattern.matches(startTime)) {
                     attendees += profileViewModel.userState.value!!
                     try {
                       calendar.set(

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -398,7 +398,10 @@ fun EditActivityScreen(
                 enabled = title.isNotEmpty() && description.isNotEmpty() && dueDate.isNotEmpty(),
                 onClick = {
                   val timeFormat = startTime?.split(":") ?: listOf()
-                  if (timeFormat.size != 2) {
+                    val timePattern = Regex("^([01]?[0-9]|2[0-3]):[0-5][0-9]$")
+
+                    if (timeFormat.size != 2 || !startTime?.let { timePattern.matches(it) }!!) {
+
                     Toast.makeText(
                             context, "Invalid format, time must be HH:MM.", Toast.LENGTH_SHORT)
                         .show()
@@ -411,7 +414,11 @@ fun EditActivityScreen(
                   }
                   val calendar = GregorianCalendar()
                   val parts = dueDate.split("/")
-                  if (parts.size == 3) {
+                  if (parts.size == 3 && timeFormat.size == 2 && durationFormat.size == 2 && startTime?.let {
+                          timePattern.matches(
+                              it
+                          )
+                      } == true) {
                     try {
                       calendar.set(
                           parts[2].toInt(),

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -398,9 +398,9 @@ fun EditActivityScreen(
                 enabled = title.isNotEmpty() && description.isNotEmpty() && dueDate.isNotEmpty(),
                 onClick = {
                   val timeFormat = startTime?.split(":") ?: listOf()
-                    val timePattern = Regex("^([01]?[0-9]|2[0-3]):[0-5][0-9]$")
+                  val timePattern = Regex("^([01]?[0-9]|2[0-3]):[0-5][0-9]$")
 
-                    if (timeFormat.size != 2 || !startTime?.let { timePattern.matches(it) }!!) {
+                  if (timeFormat.size != 2 || !startTime?.let { timePattern.matches(it) }!!) {
 
                     Toast.makeText(
                             context, "Invalid format, time must be HH:MM.", Toast.LENGTH_SHORT)
@@ -414,11 +414,10 @@ fun EditActivityScreen(
                   }
                   val calendar = GregorianCalendar()
                   val parts = dueDate.split("/")
-                  if (parts.size == 3 && timeFormat.size == 2 && durationFormat.size == 2 && startTime?.let {
-                          timePattern.matches(
-                              it
-                          )
-                      } == true) {
+                  if (parts.size == 3 &&
+                      timeFormat.size == 2 &&
+                      durationFormat.size == 2 &&
+                      startTime?.let { timePattern.matches(it) } == true) {
                     try {
                       calendar.set(
                           parts[2].toInt(),


### PR DESCRIPTION
### fix: invalid start time format in edit activity and create activity

# Explanation of the bug

 * it was possible to create activities with invalid start time such as: 65:80 or aa:bb.

# Proposed Solution


 * add the following start time conditions:
   * the hours should be between 00 and 23
   * the minutes should be between 00 and 59
   * there should be no letter
 * show a toast indicating invalid format of the start time when editing the activity using an invalid start time

 * the same changes were made in both edit activity and create activity for a coherent UX.
# Testing
 * no tests were added in this pr. I am waiting for other members to set up hilt so I could write end to end test.
  
  closes #165