### PR TITLE
Fix/liked activities register button 181

### DIFF
--- a/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -97,8 +96,8 @@ fun LikedActivitiesScreen(
                           onClick = { navigationActions.navigateTo(Screen.SIGN_UP) },
                           modifier = Modifier.testTag("signInButton"),
                       ) {
-                            Text("Go to Sign In Page", style = MaterialTheme.typography.labelLarge)
-                          }
+                        Text("Go to Sign In Page", style = MaterialTheme.typography.labelLarge)
+                      }
                     }
               }
               if (likedActivitiesList != null) {

--- a/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -41,6 +42,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
@@ -80,17 +82,23 @@ fun LikedActivitiesScreen(
           when (uiState) {
             is ListActivitiesViewModel.ActivitiesUiState.Success -> {
               if (profile == null) {
-                Text(
-                    text = "You are not logged in, Login or Register to see your liked activities",
-                    modifier =
-                        Modifier.padding(8.dp)
-                            .align(Alignment.Center)
-                            .testTag("notConnectedPrompt"),
-                    color = MaterialTheme.colorScheme.onSurface)
-                Button(
-                    onClick = { navigationActions.navigateTo(Screen.SIGN_UP) },
-                    modifier = Modifier.testTag("signInButton")) {
-                      Text("Go to Sign In Page")
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier.align(Alignment.Center)) {
+                      Text(
+                          text =
+                              "You are not logged in. Login or Register to see your liked activities.",
+                          modifier = Modifier.padding(bottom = 16.dp).testTag("notConnectedPrompt"),
+                          color = MaterialTheme.colorScheme.onSurface,
+                          style = MaterialTheme.typography.bodyMedium,
+                          textAlign = TextAlign.Center)
+                      Button(
+                          onClick = { navigationActions.navigateTo(Screen.SIGN_UP) },
+                          modifier = Modifier.testTag("signInButton"),
+                      ) {
+                            Text("Go to Sign In Page", style = MaterialTheme.typography.labelLarge)
+                          }
                     }
               }
               if (likedActivitiesList != null) {


### PR DESCRIPTION
### fix: change the login button position in liked activities


* In user Mode, the button to login in the liked activities screen  was located in the upper left corner of the screen which is not user friendly.
* Now, the go to sign in page button and the displayed text are placed at the center of the screen for a better UX.
### Testing
* No tests were written for this PR because only the placement of the button the displayed text were changed
closes #181
