### PR TITLE
Fix map permission not appearing when launching the app

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -57,12 +57,7 @@ class MainActivity : ComponentActivity() {
     if (!hasCameraPermissions(applicationContext)) {
       ActivityCompat.requestPermissions(this, CAMERAX_PERMISSIONS, CAMERA_PERMISSION_REQUEST_CODE)
     }
-    Log.d("MainActivity", "Checking location permissions")
-    if (!hasLocationPermissions(applicationContext)) {
-      Log.d("MainActivity", "Requesting location permissions")
-      ActivityCompat.requestPermissions(
-          this, LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST_CODE)
-    }
+
     auth = FirebaseAuth.getInstance()
     val currentUser = auth.currentUser
     if (currentUser != null && currentUser.isAnonymous) {
@@ -87,17 +82,6 @@ class MainActivity : ComponentActivity() {
     }
   }
 
-  private fun hasLocationPermissions(context: Context): Boolean {
-    return LOCATION_PERMISSIONS.all {
-      ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-    }
-  }
-
-  private val LOCATION_PERMISSIONS =
-      arrayOf(
-          Manifest.permission.ACCESS_FINE_LOCATION,
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-      )
   private val CAMERAX_PERMISSIONS = arrayOf(Manifest.permission.CAMERA)
 }
 


### PR DESCRIPTION
In this PR, I just moved the map permission checking to the Map screen instead of the mainActivity so that we are not asked about location when launching the app but when we go to the map.