### PR TITLE
Feature/image storage

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -72,11 +72,41 @@ class CreateActivityScreenTest {
     `when`(profileViewModel.userState).thenReturn(MutableStateFlow(testUser))
   }
 
-  private fun setUpComposeContent() {
+  @Test
+  fun createActivityAddImagesCamera() {
     composeTestRule.setContent {
       CreateActivityScreen(
           mockViewModel, mockNavigationActions, profileViewModel, mockLocationViewModel)
     }
+    composeTestRule.onNodeWithTag("addImageButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addImageButton").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("cameraScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("takePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("switchCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("activityCreateScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun createActivityAddImagesGallery() {
+    composeTestRule.setContent {
+      CreateActivityScreen(
+          mockViewModel, mockNavigationActions, profileViewModel, mockLocationViewModel)
+    }
+    composeTestRule.onNodeWithTag("addImageButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addImageButton").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").performClick()
+    composeTestRule.waitForIdle()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
@@ -2,10 +2,12 @@ package com.android.sample.ui.profile
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.sample.model.profile.ProfileViewModel
@@ -51,6 +53,41 @@ class EditProfileScreenTest {
     composeTestRule.onNodeWithTag("uploadPicture").performClick()
   }
 
+  @Test
+  fun testProfileEditionWithDialogWithCamera(){
+    composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }
+    composeTestRule
+      .onNodeWithTag("editProfileContent")
+      .performScrollToNode(hasTestTag("uploadPicture"))
+    composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("uploadPicture").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("cameraScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("takePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("switchCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("editProfileContent").assertIsDisplayed()
+  }
+
+  @Test
+  fun testProfileEditionWithDialogWithGallery(){
+    composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }
+    composeTestRule
+      .onNodeWithTag("editProfileContent")
+      .performScrollToNode(hasTestTag("uploadPicture"))
+    composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("uploadPicture").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").performClick()
+  }
   @Test
   fun testAddInterestButtonFunctionality() {
     composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }

--- a/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt
@@ -54,11 +54,11 @@ class EditProfileScreenTest {
   }
 
   @Test
-  fun testProfileEditionWithDialogWithCamera(){
+  fun testProfileEditionWithDialogWithCamera() {
     composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }
     composeTestRule
-      .onNodeWithTag("editProfileContent")
-      .performScrollToNode(hasTestTag("uploadPicture"))
+        .onNodeWithTag("editProfileContent")
+        .performScrollToNode(hasTestTag("uploadPicture"))
     composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
     composeTestRule.onNodeWithTag("uploadPicture").performClick()
     composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
@@ -76,11 +76,11 @@ class EditProfileScreenTest {
   }
 
   @Test
-  fun testProfileEditionWithDialogWithGallery(){
+  fun testProfileEditionWithDialogWithGallery() {
     composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }
     composeTestRule
-      .onNodeWithTag("editProfileContent")
-      .performScrollToNode(hasTestTag("uploadPicture"))
+        .onNodeWithTag("editProfileContent")
+        .performScrollToNode(hasTestTag("uploadPicture"))
     composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
     composeTestRule.onNodeWithTag("uploadPicture").performClick()
     composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
@@ -88,6 +88,7 @@ class EditProfileScreenTest {
     composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("galleryButton").performClick()
   }
+
   @Test
   fun testAddInterestButtonFunctionality() {
     composeTestRule.setContent { EditProfileScreen(profileViewModel, navigationActions) }

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
@@ -60,10 +60,10 @@ class ProfileCreationTest {
   }
 
   @Test
-  fun testProfileCreationWithDialogWithCamera(){
+  fun testProfileCreationWithDialogWithCamera() {
     composeTestRule
-      .onNodeWithTag("profileCreationScrollColumn")
-      .performScrollToNode(hasTestTag("uploadPicture"))
+        .onNodeWithTag("profileCreationScrollColumn")
+        .performScrollToNode(hasTestTag("uploadPicture"))
     composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
     composeTestRule.onNodeWithTag("uploadPicture").performClick()
     composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
@@ -81,10 +81,10 @@ class ProfileCreationTest {
   }
 
   @Test
-  fun testProfileCreationWithDialogWithGallery(){
+  fun testProfileCreationWithDialogWithGallery() {
     composeTestRule
-      .onNodeWithTag("profileCreationScrollColumn")
-      .performScrollToNode(hasTestTag("uploadPicture"))
+        .onNodeWithTag("profileCreationScrollColumn")
+        .performScrollToNode(hasTestTag("uploadPicture"))
     composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
     composeTestRule.onNodeWithTag("uploadPicture").performClick()
     composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
@@ -92,6 +92,7 @@ class ProfileCreationTest {
     composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("galleryButton").performClick()
   }
+
   @Test
   fun testProfileCreationScreenElementsDisplayed() {
     composeTestRule.onNodeWithTag("profileCreationTitle").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt
@@ -60,6 +60,39 @@ class ProfileCreationTest {
   }
 
   @Test
+  fun testProfileCreationWithDialogWithCamera(){
+    composeTestRule
+      .onNodeWithTag("profileCreationScrollColumn")
+      .performScrollToNode(hasTestTag("uploadPicture"))
+    composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("uploadPicture").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("cameraScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("takePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("switchCamera").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeCamera").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("profileCreationScrollColumn").assertIsDisplayed()
+  }
+
+  @Test
+  fun testProfileCreationWithDialogWithGallery(){
+    composeTestRule
+      .onNodeWithTag("profileCreationScrollColumn")
+      .performScrollToNode(hasTestTag("uploadPicture"))
+    composeTestRule.onNodeWithTag("uploadPicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("uploadPicture").performClick()
+    composeTestRule.onNodeWithTag("addImageDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("galleryButton").performClick()
+  }
+  @Test
   fun testProfileCreationScreenElementsDisplayed() {
     composeTestRule.onNodeWithTag("profileCreationTitle").assertIsDisplayed()
 

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -130,18 +130,6 @@ fun CreateActivityScreen(
         )
       },
       content = { paddingValues ->
-        if (showDialogImage) {
-          AddImageDialog(
-              onDismiss = { showDialogImage = false },
-              onGalleryClick = {
-                showDialogImage = false
-                isGalleryOpen = true
-              },
-              onCameraClick = {
-                showDialogImage = false
-                isCamOpen = true
-              })
-        }
         if (isCamOpen) {
           CameraScreen(
               paddingValues = paddingValues,

--- a/app/src/main/java/com/android/sample/ui/camera/CameraScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/camera/CameraScreen.kt
@@ -30,7 +30,7 @@ fun CameraScreen(
 ) {
   Box(modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("cameraScreen")) {
     CameraPreview(controller, Modifier.fillMaxSize())
-    IconButton(onClick = isCamOpen, modifier = Modifier.align(Alignment.TopEnd)) {
+    IconButton(onClick = isCamOpen, modifier = Modifier.align(Alignment.TopEnd).testTag("closeCamera")) {
       Icon(Icons.Default.ArrowBack, contentDescription = "Close camera")
     }
     IconButton(

--- a/app/src/main/java/com/android/sample/ui/camera/CameraScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/camera/CameraScreen.kt
@@ -30,9 +30,10 @@ fun CameraScreen(
 ) {
   Box(modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("cameraScreen")) {
     CameraPreview(controller, Modifier.fillMaxSize())
-    IconButton(onClick = isCamOpen, modifier = Modifier.align(Alignment.TopEnd).testTag("closeCamera")) {
-      Icon(Icons.Default.ArrowBack, contentDescription = "Close camera")
-    }
+    IconButton(
+        onClick = isCamOpen, modifier = Modifier.align(Alignment.TopEnd).testTag("closeCamera")) {
+          Icon(Icons.Default.ArrowBack, contentDescription = "Close camera")
+        }
     IconButton(
         onClick = {
           takePhoto(

--- a/app/src/main/java/com/android/sample/ui/dialogs/AddImageDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/AddImageDialog.kt
@@ -61,7 +61,8 @@ fun AddImageDialog(onDismiss: () -> Unit, onGalleryClick: () -> Unit, onCameraCl
 
           Button(
               onClick = onGalleryClick,
-              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("galleryButton")) {
+              modifier =
+                  Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("galleryButton")) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.background(Color.Transparent)) {
@@ -76,7 +77,8 @@ fun AddImageDialog(onDismiss: () -> Unit, onGalleryClick: () -> Unit, onCameraCl
 
           Button(
               onClick = onCameraClick,
-              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("cameraButton")) {
+              modifier =
+                  Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("cameraButton")) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.background(Color.Transparent)) {

--- a/app/src/main/java/com/android/sample/ui/dialogs/AddImageDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/AddImageDialog.kt
@@ -46,7 +46,7 @@ fun AddImageDialog(onDismiss: () -> Unit, onGalleryClick: () -> Unit, onCameraCl
                     .height(200.dp)
                     .background(
                         color = Color.White, shape = RoundedCornerShape(size = MEDIUM_PADDING.dp))
-                    .testTag("addUserDialog"),
+                    .testTag("addImageDialog"),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -61,7 +61,7 @@ fun AddImageDialog(onDismiss: () -> Unit, onGalleryClick: () -> Unit, onCameraCl
 
           Button(
               onClick = onGalleryClick,
-              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
+              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("galleryButton")) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.background(Color.Transparent)) {
@@ -76,7 +76,7 @@ fun AddImageDialog(onDismiss: () -> Unit, onGalleryClick: () -> Unit, onCameraCl
 
           Button(
               onClick = onCameraClick,
-              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
+              modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("cameraButton")) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.background(Color.Transparent)) {

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,8 +18,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -72,8 +75,10 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
   var isGalleryOpen by remember { mutableStateOf(false) }
   var showDialogImage by remember { mutableStateOf(false) }
   var photo by remember { mutableStateOf(profile.photo) }
+    val scrollState = rememberScrollState()
 
-  val context = LocalContext.current
+
+    val context = LocalContext.current
   var selectedImage by remember { mutableStateOf<Bitmap?>(null) }
 
   Scaffold(
@@ -145,7 +150,8 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
               })
         } else {
           Column(
-              modifier = Modifier.fillMaxSize().padding(paddingValues).padding(MEDIUM_PADDING.dp),
+              modifier = Modifier.fillMaxSize().padding(paddingValues).padding(MEDIUM_PADDING.dp)
+                  .testTag("editProfileContent").verticalScroll(scrollState),
               verticalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
                 ProfileImage(
                     userId = profile.id,

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -75,10 +74,9 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
   var isGalleryOpen by remember { mutableStateOf(false) }
   var showDialogImage by remember { mutableStateOf(false) }
   var photo by remember { mutableStateOf(profile.photo) }
-    val scrollState = rememberScrollState()
+  val scrollState = rememberScrollState()
 
-
-    val context = LocalContext.current
+  val context = LocalContext.current
   var selectedImage by remember { mutableStateOf<Bitmap?>(null) }
 
   Scaffold(
@@ -150,8 +148,12 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
               })
         } else {
           Column(
-              modifier = Modifier.fillMaxSize().padding(paddingValues).padding(MEDIUM_PADDING.dp)
-                  .testTag("editProfileContent").verticalScroll(scrollState),
+              modifier =
+                  Modifier.fillMaxSize()
+                      .padding(paddingValues)
+                      .padding(MEDIUM_PADDING.dp)
+                      .testTag("editProfileContent")
+                      .verticalScroll(scrollState),
               verticalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
                 ProfileImage(
                     userId = profile.id,

--- a/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
@@ -152,4 +152,35 @@ class ActivitiesRepositoryFirestoreTest {
 
     assert(failureCalled)
   }
+
+  @Test
+  fun performFirestoreOperation_callsOnSuccess() {
+    val mockTask = Tasks.forResult<Void>(null)
+
+    var successCalled = false
+    activitiesRepositoryFirestore.performFirestoreOperation(
+        mockTask,
+        onSuccess = { successCalled = true },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assert(successCalled)
+  }
+
+  @Test
+  fun performFirestoreOperation_callsOnFailure() {
+    val exception = FirebaseFirestoreException("Error", FirebaseFirestoreException.Code.ABORTED)
+    val mockTask = Tasks.forException<Void>(exception)
+
+    var failureCalled = false
+    activitiesRepositoryFirestore.performFirestoreOperation(
+        mockTask,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { failureCalled = true })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assert(failureCalled)
+  }
 }

--- a/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
@@ -1,7 +1,6 @@
 package com.android.sample.model.profile
 
 import com.android.sample.resources.dummydata.testUser
-import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -15,6 +14,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
@@ -29,8 +29,6 @@ class ProfilesRepositoryFirestoreTest {
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
-
-    // Initialize Firebase if necessary
 
     profileRepositoryFirestore = ProfilesRepositoryFirestore(mockFirestore)
 
@@ -53,7 +51,6 @@ class ProfilesRepositoryFirestoreTest {
 
   @Test
   fun updateProfile_shouldCallFirestoreCollection() {
-
     `when`(mockDocumentReference.set(testUser)).thenReturn(Tasks.forResult(null))
 
     profileRepositoryFirestore.updateProfile(testUser, onSuccess = {}, onFailure = {})
@@ -62,22 +59,114 @@ class ProfilesRepositoryFirestoreTest {
   }
 
   @Test
-  fun updateProfile_shouldCallFirestoreCollectionn() {
-    val mockTaskVoid: Task<Void> = Tasks.forResult(null)
-    `when`(mockDocumentReference.set(testUser)).thenReturn(mockTaskVoid)
-
-    profileRepositoryFirestore.updateProfile(testUser, onSuccess = {}, onFailure = {})
-
-    verify(mockDocumentReference).set(testUser)
-  }
-
-  @Test
   fun addProfileToDatabase_shouldCallFirestoreToAddUserProfile() {
-    val mockTaskVoid: Task<Void> = Tasks.forResult(null)
+    val mockTaskVoid = Tasks.forResult<Void>(null)
     `when`(mockDocumentReference.set(testUser)).thenReturn(mockTaskVoid)
 
     profileRepositoryFirestore.addProfileToDatabase(testUser, onSuccess = {}, onFailure = {})
 
     verify(mockDocumentReference).set(testUser)
+  }
+
+  @Test
+  fun addActivity_shouldCallFirestoreToAddActivity() {
+    `when`(mockDocumentReference.update(eq("activities"), any())).thenReturn(Tasks.forResult(null))
+
+    profileRepositoryFirestore.addActivity("1", "activityId", onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).update(eq("activities"), any())
+  }
+
+  @Test
+  fun addLikedActivity_shouldCallFirestoreToAddLikedActivity() {
+    `when`(mockDocumentReference.update(eq("likedActivities"), any()))
+        .thenReturn(Tasks.forResult(null))
+
+    profileRepositoryFirestore.addLikedActivity("1", "activityId", onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).update(eq("likedActivities"), any())
+  }
+
+  @Test
+  fun removeLikedActivity_shouldCallFirestoreToRemoveLikedActivity() {
+    `when`(mockDocumentReference.update(eq("likedActivities"), any()))
+        .thenReturn(Tasks.forResult(null))
+
+    profileRepositoryFirestore.removeLikedActivity(
+        "1", "activityId", onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).update(eq("likedActivities"), any())
+  }
+
+  @Test
+  fun getUser_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.getUser(
+        "1",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun addActivity_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.update(eq("activities"), any()))
+        .thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.addActivity(
+        "1",
+        "activityId",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun addLikedActivity_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.update(eq("likedActivities"), any()))
+        .thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.addLikedActivity(
+        "1",
+        "activityId",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun removeLikedActivity_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.update(eq("likedActivities"), any()))
+        .thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.removeLikedActivity(
+        "1",
+        "activityId",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun updateProfile_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.set(testUser)).thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.updateProfile(
+        testUser,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun addProfileToDatabase_shouldCallFailureCallbackOnError() {
+    val exception = Exception("Test exception")
+    `when`(mockDocumentReference.set(testUser)).thenReturn(Tasks.forException(exception))
+
+    profileRepositoryFirestore.addProfileToDatabase(
+        testUser,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { assert(it == exception) })
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the Android test and main codebase, focusing primarily on adding new test cases for image handling and improving the UI components for image dialogs. The most important changes are grouped into test additions

### Test Additions:

* [`app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt`](diffhunk://#diff-afbcad4af55e65a0899a5875391d0a7dee76c825350b09f11982f44c33ca755cL75-R109): Added tests for creating activities with images from the camera and gallery.
* [`app/src/androidTest/java/com/android/sample/ui/profile/EditProfileTest.kt`](diffhunk://#diff-fd25ce09bdafa1887e86b4f0620b8e3e208ddf1426958a306172014b0aeb1365R5-R10): Added tests for editing profiles with images from the camera and gallery. [[1]](diffhunk://#diff-fd25ce09bdafa1887e86b4f0620b8e3e208ddf1426958a306172014b0aeb1365R5-R10) [[2]](diffhunk://#diff-fd25ce09bdafa1887e86b4f0620b8e3e208ddf1426958a306172014b0aeb1365R56-R91)
* [`app/src/androidTest/java/com/android/sample/ui/profile/ProfileCreationTest.kt`](diffhunk://#diff-d3dd2195ea4e3747a8f7e6ac820b2b5f59808e6218197f03ed29f5dab91df463R62-R95): Added tests for profile creation with images from the camera and gallery.
* [`app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt`](diffhunk://#diff-793f5205887ff6bdef25c8978ca4f03413ee5ab271d836d0f0830049186e84b4R155-R185): Added tests for Firestore operations to ensure success and failure callbacks are called appropriately.
* [`app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt`](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79L4): Added multiple tests for Firestore operations related to profile and activity handling, including success and failure scenarios. [[1]](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79L4) [[2]](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79R17) [[3]](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79L33-L34) [[4]](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79L56) [[5]](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79L65-R170)
