### PR TITLE
add MAP_API_KEY in CI.yaml from github secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
         run: |
           ./gradlew assembleRelease \
           -Pandroid.injected.signing.store.file=$KEYSTORE_PATH \


### PR DESCRIPTION
just added MAP_API_KEY in CI.yaml from github secrets to build the apk with the correct value of MAP_API_KEY.