### PR TITLE
add:add tests activity and profile repository

### DIFF
--- a/app/src/main/java/com/android/sample/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/profile/ProfilesRepositoryFirestore.kt
@@ -28,7 +28,7 @@ open class ProfilesRepositoryFirestore @Inject constructor(private val db: Fireb
     }
   }
 
-  private fun documentToUser(document: DocumentSnapshot): User? {
+  fun documentToUser(document: DocumentSnapshot): User? {
     return try {
       User(
           id = document.id,

--- a/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
@@ -215,3 +215,46 @@ val userWithActivities =
 const val email = "test@example.com"
 const val idToken = "testGoogleIdToken"
 val uid = "testUid"
+
+val documentId = "testDocumentId"
+val validData =
+    mapOf(
+        "title" to "Sample Title",
+        "description" to "Sample Description",
+        "date" to Timestamp.now(),
+        "startTime" to "10:00",
+        "duration" to "2 hours",
+        "price" to 15.0,
+        "location" to mapOf("latitude" to 12.34, "longitude" to 56.78, "name" to "Sample Location"),
+        "creator" to "creatorUserId",
+        "images" to listOf("image1.jpg", "image2.jpg"),
+        "placesLeft" to 5L,
+        "maxPlaces" to 20L,
+        "status" to "ACTIVE",
+        "type" to "SOLO",
+        "participants" to
+            listOf(
+                mapOf(
+                    "name" to "John",
+                    "surname" to "Doe",
+                    "id" to "user123",
+                    "interests" to listOf("hiking", "reading"),
+                    "activities" to listOf("activity1", "activity2"),
+                    "photo" to "profile.jpg",
+                    "likedActivities" to listOf("liked1", "liked2"))),
+        "comments" to
+            listOf(
+                mapOf(
+                    "uid" to "comment1",
+                    "userId" to "user123",
+                    "userName" to "John Doe",
+                    "content" to "Nice activity!",
+                    "timestamp" to Timestamp.now(),
+                    "replies" to
+                        listOf(
+                            mapOf(
+                                "uid" to "reply1",
+                                "userId" to "user456",
+                                "userName" to "Jane Smith",
+                                "content" to "I agree!",
+                                "timestamp" to Timestamp.now())))))

--- a/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt
@@ -8,9 +8,13 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -168,5 +172,124 @@ class ProfilesRepositoryFirestoreTest {
         testUser,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assert(it == exception) })
+  }
+
+  @Test
+  fun `documentToUser returns User when document is valid`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.id).thenReturn("12345")
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn("Doe")
+    `when`(document.get("interests")).thenReturn(listOf("reading", "hiking"))
+    `when`(document.get("activities")).thenReturn(listOf("running", "swimming"))
+    `when`(document.getString("photo")).thenReturn("photo_url")
+    `when`(document.get("likedActivities")).thenReturn(listOf("cycling"))
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNotNull(user)
+    assertEquals("12345", user?.id)
+    assertEquals("John", user?.name)
+    assertEquals("Doe", user?.surname)
+    assertEquals(listOf("reading", "hiking"), user?.interests)
+    assertEquals(listOf("running", "swimming"), user?.activities)
+    assertEquals("photo_url", user?.photo)
+    assertEquals(listOf("cycling"), user?.likedActivities)
+  }
+
+  @Test
+  fun `documentToUser returns null when name is missing`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn(null)
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
+  }
+
+  @Test
+  fun `documentToUser returns null when surname is missing`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn(null)
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
+  }
+
+  @Test
+  fun `documentToUser returns null when interests is not a List`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn("Doe")
+    `when`(document.get("interests")).thenReturn("invalid_value")
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
+  }
+
+  @Test
+  fun `documentToUser returns null when activities is not a List`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn("Doe")
+    `when`(document.get("interests")).thenReturn(listOf("reading"))
+    `when`(document.get("activities")).thenReturn("invalid_value")
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
+  }
+
+  @Test
+  fun `documentToUser returns null when photo is missing`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn("Doe")
+    `when`(document.get("interests")).thenReturn(listOf("reading"))
+    `when`(document.get("activities")).thenReturn(listOf("running"))
+    `when`(document.getString("photo")).thenReturn(null)
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
+  }
+
+  @Test
+  fun `documentToUser returns null when likedActivities is not a List`() {
+    // Arrange
+    val document = mock(DocumentSnapshot::class.java)
+    `when`(document.getString("name")).thenReturn("John")
+    `when`(document.getString("surname")).thenReturn("Doe")
+    `when`(document.get("interests")).thenReturn(listOf("reading"))
+    `when`(document.get("activities")).thenReturn(listOf("running"))
+    `when`(document.getString("photo")).thenReturn("photo_url")
+    `when`(document.get("likedActivities")).thenReturn("invalid_value")
+
+    // Act
+    val user = profileRepositoryFirestore.documentToUser(document)
+
+    // Assert
+    assertNull(user)
   }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling and testing of data conversion in the Firestore repositories for activities and profiles. The most important changes include adding a new method to convert Firestore documents to `Activity` objects, improving the handling of optional fields, and adding comprehensive tests for these conversions.

Improvements to data conversion:

* [`app/src/main/java/com/android/sample/model/activity/ActivitiesRepositoryFirestore.kt`](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eR40-R50): Added the `documentToActivity` method to convert Firestore documents to `Activity` objects and handle null data gracefully.
* [`app/src/main/java/com/android/sample/model/profile/ProfilesRepositoryFirestore.kt`](diffhunk://#diff-81c1ee404a111b80cde0aef5f6e8c299f113acdcdf36eac42dce25b3bbcab762L31-R31): Changed the `documentToUser` method to be public for better accessibility and testing.

Code formatting and cleanup:

* [`app/src/main/java/com/android/sample/model/activity/ActivitiesRepositoryFirestore.kt`](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eL48-R61): Improved code formatting for better readability and consistency. [[1]](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eL48-R61) [[2]](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eL71-R86) [[3]](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eL93-R101) [[4]](diffhunk://#diff-7bd7c892664a67b4c783fb524dd83adf8f320960acfe23d96c79f716942df22eL111-L116)

Test enhancements:

* [`app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt`](diffhunk://#diff-793f5205887ff6bdef25c8978ca4f03413ee5ab271d836d0f0830049186e84b4R194-R241): Added tests for the `documentToActivity` method to ensure it handles valid data and missing optional fields correctly.
* [`app/src/test/java/com/android/sample/model/profile/ProfilesRepositoryFirestoreTest.kt`](diffhunk://#diff-d3437fa5075f215f62585f16e0dab912f8d548129580d9aad68f258e10a86b79R176-R294): Added tests for the `documentToUser` method to verify it returns a `User` object when the document is valid and handles various invalid cases gracefully.

Dummy data updates:

* [`app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt`](diffhunk://#diff-8df2df9f0a32b242dd3c8dbfdb72fc3772a60855ca3134840504da07348849d8R218-R260): Added `documentId` and `validData` for use in tests to ensure the `documentToActivity` method works as expected.