### PR TITLE
Add Activity Details Preview on the map

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
@@ -55,14 +55,14 @@ class MapScreenTest {
     val stateFlow = MutableStateFlow(uiState)
     Mockito.doReturn(stateFlow).`when`(listActivitiesViewModel).uiState
     `when`(navigationActions.currentRoute()).thenReturn(Screen.MAP)
-    composeTestRule.setContent {
-      MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
-    }
+
   }
 
   @Test
   fun testMapScreenIsDisplayed() {
-
+    composeTestRule.setContent {
+      MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
+    }
     composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("centerOnCurrentLocation").assertIsDisplayed()
@@ -70,7 +70,26 @@ class MapScreenTest {
 
   @Test
   fun testCenterOnCurrentLocationTriggersGetCurrentLocation() {
-
+    composeTestRule.setContent {
+      MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
+    }
     verify(mockRepository).getCurrentLocation(any(), any())
   }
+
+    @Test
+    fun activityDetailsDisplayed(){
+      composeTestRule.setContent { DisplayActivity(activity) }
+      composeTestRule.onNodeWithTag("activityDetails").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("activityTitle").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("activityDescription").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("activityDate").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("calendarIcon").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("calendarText").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("activityLocation").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("locationIcon").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("locationText").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("activityPrice").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("priceText").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("placesLeft").assertIsDisplayed()
+    }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
@@ -17,7 +17,6 @@ import com.android.sample.resources.dummydata.activity
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import kotlinx.coroutines.flow.MutableStateFlow
-import okhttp3.internal.wait
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -58,7 +57,6 @@ class MapScreenTest {
     val stateFlow = MutableStateFlow(uiState)
     Mockito.doReturn(stateFlow).`when`(listActivitiesViewModel).uiState
     `when`(navigationActions.currentRoute()).thenReturn(Screen.MAP)
-
   }
 
   @Test
@@ -79,25 +77,25 @@ class MapScreenTest {
     verify(mockRepository).getCurrentLocation(any(), any())
   }
 
-    @Test
-    fun activityDetailsDisplayed(){
-      composeTestRule.setContent { DisplayActivity(activity) }
-      composeTestRule.onNodeWithTag("activityDetails").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("activityTitle").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("activityDescription").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("activityDate").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("calendarIcon").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("calendarText").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("activityLocation").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("locationIcon").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("locationText").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("activityPrice").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("priceText").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("placesLeft").assertIsDisplayed()
-    }
+  @Test
+  fun activityDetailsDisplayed() {
+    composeTestRule.setContent { DisplayActivity(activity) }
+    composeTestRule.onNodeWithTag("activityDetails").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activityTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activityDescription").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activityDate").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("calendarIcon").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("calendarText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activityLocation").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("locationIcon").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("locationText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activityPrice").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("priceText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("placesLeft").assertIsDisplayed()
+  }
 
   @Test
-  fun seeActivityDetails(){
+  fun seeActivityDetails() {
     composeTestRule.setContent { SeeMoreDetailsButton(navigationActions) }
     composeTestRule.onNodeWithText("See more details").assertIsDisplayed()
     composeTestRule.onNodeWithTag("seeMoreDetailsButton").performClick()

--- a/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
 import com.android.sample.model.activity.ActivitiesRepository
@@ -15,6 +17,7 @@ import com.android.sample.resources.dummydata.activity
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import kotlinx.coroutines.flow.MutableStateFlow
+import okhttp3.internal.wait
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -92,4 +95,12 @@ class MapScreenTest {
       composeTestRule.onNodeWithTag("priceText").assertIsDisplayed()
       composeTestRule.onNodeWithTag("placesLeft").assertIsDisplayed()
     }
+
+  @Test
+  fun seeActivityDetails(){
+    composeTestRule.setContent { SeeMoreDetailsButton(navigationActions) }
+    composeTestRule.onNodeWithText("See more details").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("seeMoreDetailsButton").performClick()
+    verify(navigationActions).navigateTo(Screen.ACTIVITY_DETAILS)
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -161,13 +161,11 @@ fun MapScreen(
         onDismissRequest = { showBottomSheet = false },
     ) {
       Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-
         Row(
             modifier = Modifier.fillMaxWidth().padding(8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
-
 
               IconButton(onClick = { showBottomSheet = false }) {
                 Icon(
@@ -176,7 +174,7 @@ fun MapScreen(
                     tint = MaterialTheme.colorScheme.onSurface)
               }
             }
-          selectedActivity?.let { DisplayActivity(activity = it) }
+        selectedActivity?.let { DisplayActivity(activity = it) }
 
         Spacer(modifier = Modifier.height(16.dp))
       }
@@ -187,7 +185,6 @@ fun MapScreen(
 @Composable
 fun DisplayActivity(activity: Activity) {
   Column(modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activityDetails")) {
-   
     if (activity.images.isNotEmpty()) {
       AsyncImage(
           model = activity.images.first(),
@@ -200,7 +197,6 @@ fun DisplayActivity(activity: Activity) {
           contentScale = ContentScale.Crop)
       Spacer(modifier = Modifier.height(12.dp))
     }
-
 
     Text(
         text = activity.title,

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -176,9 +176,7 @@ fun MapScreen(
                     tint = MaterialTheme.colorScheme.onSurface)
               }
             }
-        if (selectedActivity != null) {
-          DisplayActivity(activity = selectedActivity!!)
-        }
+          selectedActivity?.let { DisplayActivity(activity = it) }
 
         Spacer(modifier = Modifier.height(16.dp))
       }

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -34,8 +34,10 @@ import coil.compose.AsyncImage
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.map.LocationViewModel
+import com.android.sample.resources.C.Tag.LARGE_IMAGE_SIZE
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
+import com.android.sample.resources.C.Tag.TEXT_FONTSIZE
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
@@ -165,7 +167,7 @@ fun MapScreen(
       Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp),
-            horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
+            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
 
@@ -193,11 +195,11 @@ fun DisplayActivity(activity: Activity) {
           contentDescription = "Activity image",
           modifier =
               Modifier.fillMaxWidth()
-                  .height(200.dp)
-                  .clip(RoundedCornerShape(12.dp))
+                  .height(LARGE_IMAGE_SIZE.dp)
+                  .clip(RoundedCornerShape(TEXT_FONTSIZE.dp))
                   .testTag("activityImage"),
           contentScale = ContentScale.Crop)
-      Spacer(modifier = Modifier.height(12.dp))
+      Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
     }
 
     Text(
@@ -211,7 +213,7 @@ fun DisplayActivity(activity: Activity) {
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDescription"),
     )
-    Spacer(modifier = Modifier.height(12.dp))
+    Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -240,7 +242,7 @@ fun DisplayActivity(activity: Activity) {
                 modifier = Modifier.testTag("locationText"))
           }
     }
-    Spacer(modifier = Modifier.height(12.dp))
+    Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
 
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -254,7 +256,7 @@ fun DisplayActivity(activity: Activity) {
               style = MaterialTheme.typography.bodyMedium,
               modifier = Modifier.testTag("placesLeft"))
         }
-    Spacer(modifier = Modifier.height(12.dp))
+    Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
   }
 }
 

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -191,7 +191,7 @@ fun MapScreen(
                     IconButton(onClick = { showBottomSheet = false }) {
                         Icon(
                             imageVector = Icons.Default.Close,
-                            contentDescription = "Fermer",
+                            contentDescription = "Close",
                             tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
@@ -217,7 +217,7 @@ fun DisplayActivity(activity: Activity) {
         if (activity.images.isNotEmpty()) {
             AsyncImage(
                 model = activity.images.first(),
-                contentDescription = "Image de l'activité",
+                contentDescription = "Activity image",
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(200.dp)
@@ -240,7 +240,7 @@ fun DisplayActivity(activity: Activity) {
         )
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Date et localisation
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(bottom = 8.dp)
@@ -259,32 +259,32 @@ fun DisplayActivity(activity: Activity) {
             ) {
                 Icon(
                     imageVector = Icons.Default.LocationOn,
-                    contentDescription = "Lieu",
+                    contentDescription = "Location",
                     tint = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = "Lieu: ${activity.location!!.name}")
+                Text(text = "Location: ${activity.location!!.name}")
             }
         }
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Prix et places disponibles
+
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                text = "Prix: ${activity.price}€",
+                text = "Price: ${activity.price}€",
                 style = MaterialTheme.typography.bodyMedium
             )
             Text(
-                text = "Places restantes: ${activity.placesLeft}/${activity.maxPlaces}",
+                text = "Places left: ${activity.placesLeft}/${activity.maxPlaces}",
                 style = MaterialTheme.typography.bodyMedium
             )
         }
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Participants
+
 
     }
 }

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -46,6 +47,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.launch
+import org.junit.Test
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -117,6 +119,7 @@ fun MapScreen(
                                 snippet = item.description,
                                 onClick = {
                                     selectedActivity = item
+                                    selectedActivity?.let { listActivitiesViewModel.selectActivity(it) }
                                     showBottomSheet = true
                                     true
                                 }
@@ -177,16 +180,8 @@ fun MapScreen(
                     horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Bouton "See more details" à gauche
-                    Button(
-                        onClick = {
-                            selectedActivity?.let { listActivitiesViewModel.selectActivity(it) }
-                            navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
-                            showBottomSheet = false
-                        },
-                    ) {
-                        Text("See more details")
-                    }
+
+                    SeeMoreDetailsButton(navigationActions)
 
                     // Icône de fermeture (croix) à droite
                     IconButton(onClick = { showBottomSheet = false }) {
@@ -297,6 +292,22 @@ fun DisplayActivity(activity: Activity) {
 
 
 
+    }
+
+
+}
+@Composable
+
+fun SeeMoreDetailsButton(navigationActions: NavigationActions){
+    Button(
+        modifier = Modifier.testTag("seeMoreDetailsButton"),
+        onClick = {
+
+            navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
+
+        },
+    ) {
+        Text(text="See more details")
     }
 }
 

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -164,7 +164,7 @@ fun MapScreen(
 
         Row(
             modifier = Modifier.fillMaxWidth().padding(8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
+            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
 
@@ -187,7 +187,7 @@ fun MapScreen(
 @Composable
 fun DisplayActivity(activity: Activity) {
   Column(modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activityDetails")) {
-    // Image en haut
+   
     if (activity.images.isNotEmpty()) {
       AsyncImage(
           model = activity.images.first(),
@@ -201,7 +201,7 @@ fun DisplayActivity(activity: Activity) {
       Spacer(modifier = Modifier.height(12.dp))
     }
 
-    // Titre et description
+
     Text(
         text = activity.title,
         style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -135,7 +135,7 @@ fun MapScreen(
           FloatingActionButton(
               modifier =
                   Modifier.align(Alignment.BottomStart)
-                      .padding(16.dp)
+                      .padding(MEDIUM_PADDING.dp)
                       .testTag("centerOnCurrentLocation"),
               onClick = {
                 coroutineScope.launch {
@@ -162,7 +162,7 @@ fun MapScreen(
     ModalBottomSheet(
         onDismissRequest = { showBottomSheet = false },
     ) {
-      Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp),
             horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
@@ -186,7 +186,7 @@ fun MapScreen(
 
 @Composable
 fun DisplayActivity(activity: Activity) {
-  Column(modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activityDetails")) {
+  Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("activityDetails")) {
     if (activity.images.isNotEmpty()) {
       AsyncImage(
           model = activity.images.first(),
@@ -203,38 +203,38 @@ fun DisplayActivity(activity: Activity) {
     Text(
         text = activity.title,
         style = MaterialTheme.typography.bodyLarge,
-        modifier = Modifier.padding(bottom = 8.dp).testTag("activityTitle"),
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityTitle"),
     )
     Text(
         text = activity.description,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp).testTag("activityDescription"),
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDescription"),
     )
     Spacer(modifier = Modifier.height(12.dp))
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(bottom = 8.dp).testTag("activityDate")) {
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDate")) {
           Icon(
               imageVector = Icons.Default.CalendarToday,
               contentDescription = "Date",
               tint = MaterialTheme.colorScheme.primary,
               modifier = Modifier.testTag("calendarIcon"))
-          Spacer(modifier = Modifier.width(8.dp))
+          Spacer(modifier = Modifier.width(STANDARD_PADDING.dp))
           Text(
               text = "Date: ${activity.date.toDate()}", modifier = Modifier.testTag("calendarText"))
         }
     if (activity.location != null) {
       Row(
           verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.padding(bottom = 8.dp).testTag("activityLocation")) {
+          modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityLocation")) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
                 contentDescription = "Location",
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.testTag("locationIcon"))
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(STANDARD_PADDING.dp))
             Text(
                 text = "Location: ${activity.location!!.name}",
                 modifier = Modifier.testTag("locationText"))

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -108,6 +108,7 @@ fun MapScreen(
                         .filter { it.location != null }
                         .forEach { item ->
                             Marker(
+
                                 state =
                                 MarkerState(
                                     position =
@@ -211,7 +212,7 @@ fun DisplayActivity(activity: Activity) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(16.dp).testTag("activityDetails")
     ) {
         // Image en haut
         if (activity.images.isNotEmpty()) {
@@ -221,7 +222,7 @@ fun DisplayActivity(activity: Activity) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(200.dp)
-                    .clip(RoundedCornerShape(12.dp)),
+                    .clip(RoundedCornerShape(12.dp)).testTag("activityImage"),
                 contentScale = ContentScale.Crop
             )
             Spacer(modifier = Modifier.height(12.dp))
@@ -231,39 +232,47 @@ fun DisplayActivity(activity: Activity) {
         Text(
             text = activity.title,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp).testTag("activityTitle"),
         )
         Text(
             text = activity.description,
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp).testTag("activityDescription"),
         )
         Spacer(modifier = Modifier.height(12.dp))
 
 
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = 8.dp).testTag("activityDate")
         ) {
             Icon(
                 imageVector = Icons.Default.CalendarToday,
                 contentDescription = "Date",
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.testTag("calendarIcon")
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text(text = "Date: ${activity.date.toDate()}")
+            Text(text = "Date: ${activity.date.toDate()}",
+                modifier = Modifier.testTag("calendarText")
+            )
         }
         if (activity.location != null) {
             Row(
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 8.dp).testTag("activityLocation")
             ) {
                 Icon(
                     imageVector = Icons.Default.LocationOn,
                     contentDescription = "Location",
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("locationIcon")
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = "Location: ${activity.location!!.name}")
+                Text(text = "Location: ${activity.location!!.name}",
+                    modifier = Modifier.testTag("locationText")
+                )
             }
         }
         Spacer(modifier = Modifier.height(12.dp))
@@ -271,15 +280,17 @@ fun DisplayActivity(activity: Activity) {
 
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().testTag("activityPrice")
         ) {
             Text(
                 text = "Price: ${activity.price}€",
-                style = MaterialTheme.typography.bodyMedium
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("priceText")
             )
             Text(
                 text = "Places left: ${activity.placesLeft}/${activity.maxPlaces}",
-                style = MaterialTheme.typography.bodyMedium
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("placesLeft")
             )
         }
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -6,24 +6,40 @@ import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import coil.compose.AsyncImage
+import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.map.LocationViewModel
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
+import com.android.sample.ui.navigation.Screen
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
@@ -31,104 +47,246 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapScreen(
     navigationActions: NavigationActions,
     locationViewModel: LocationViewModel,
     listActivitiesViewModel: ListActivitiesViewModel
 ) {
-  val context = LocalContext.current
-  val currentLocation by locationViewModel.currentLocation.collectAsState()
-  val coroutineScope = rememberCoroutineScope()
-  val activities by listActivitiesViewModel.uiState.collectAsState()
-  val defaultLocation = LatLng(46.519962, 6.633597) // EPFL
-  val firstToDoLocation =
-      try {
-        val loc =
-            (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
-                .activities
-                .firstNotNullOf { it.location }
-        LatLng(loc.latitude, loc.longitude)
-      } catch (_: NoSuchElementException) {
-        defaultLocation
-      }
-  val cameraPositionState = rememberCameraPositionState {
-    position = CameraPosition.fromLatLngZoom(firstToDoLocation, 10f)
-  }
+    val context = LocalContext.current
+    val currentLocation by locationViewModel.currentLocation.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val activities by listActivitiesViewModel.uiState.collectAsState()
+    val defaultLocation = LatLng(46.519962, 6.633597) // EPFL
+    var selectedActivity by remember { mutableStateOf<Activity?>(null) }
+    var showBottomSheet by remember { mutableStateOf(false) }
 
-  // Activity result launcher to request permissions
-  val locationPermissionLauncher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.RequestPermission(),
-          onResult = { isGranted ->
-            if (isGranted) {
-              locationViewModel.fetchCurrentLocation()
-            } else {
-              Log.d("MapScreen", "Location permission denied by the user.")
-            }
-          })
-
-  LaunchedEffect(Unit) {
-    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED) {
-      locationViewModel.fetchCurrentLocation()
-    } else {
-      locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-    }
-  }
-
-  Scaffold(
-      content = { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
-          GoogleMap(
-              modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
-              cameraPositionState = cameraPositionState) {
+    val firstToDoLocation =
+        try {
+            val loc =
                 (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
                     .activities
-                    .filter { it.location != null }
-                    .forEach { item ->
-                      Marker(
-                          state =
-                              MarkerState(
-                                  position =
-                                      LatLng(item.location!!.latitude, item.location!!.longitude)),
-                          title = item.title,
-                          snippet = item.description,
-                      )
-                    }
-                currentLocation?.let {
-                  Marker(
-                      state = rememberMarkerState(position = LatLng(it.latitude, it.longitude)),
-                      title = it.name,
-                      snippet = "Lat: ${it.latitude}, Lon: ${it.longitude}",
-                      icon =
-                          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
-                }
-              }
-
-          FloatingActionButton(
-              modifier =
-                  Modifier.align(Alignment.BottomStart)
-                      .padding(16.dp)
-                      .testTag("centerOnCurrentLocation"),
-              onClick = {
-                coroutineScope.launch {
-                  currentLocation?.let {
-                    val locationLatLng = LatLng(it.latitude, it.longitude)
-                    cameraPositionState.animate(
-                        update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
-                        durationMs = 800)
-                  }
-                }
-              }) {
-                Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
-              }
+                    .firstNotNullOf { it.location }
+            LatLng(loc.latitude, loc.longitude)
+        } catch (_: NoSuchElementException) {
+            defaultLocation
         }
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = Route.MAP)
-      })
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(firstToDoLocation, 10f)
+    }
+
+    // Activity result launcher to request permissions
+    val locationPermissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+            onResult = { isGranted ->
+                if (isGranted) {
+                    locationViewModel.fetchCurrentLocation()
+                } else {
+                    Log.d("MapScreen", "Location permission denied by the user.")
+                }
+            })
+
+    LaunchedEffect(Unit) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED) {
+            locationViewModel.fetchCurrentLocation()
+        } else {
+            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    Scaffold(
+        content = { padding ->
+            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
+                    cameraPositionState = cameraPositionState) {
+                    (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
+                        .activities
+                        .filter { it.location != null }
+                        .forEach { item ->
+                            Marker(
+                                state =
+                                MarkerState(
+                                    position =
+                                    LatLng(item.location!!.latitude, item.location!!.longitude)),
+                                title = item.title,
+                                snippet = item.description,
+                                onClick = {
+                                    selectedActivity = item
+                                    showBottomSheet = true
+                                    true
+                                }
+                            )
+                        }
+                    currentLocation?.let {
+                        Marker(
+                            state = rememberMarkerState(position = LatLng(it.latitude, it.longitude)),
+                            title = it.name,
+                            snippet = "Lat: ${it.latitude}, Lon: ${it.longitude}",
+                            icon =
+                            BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
+                    }
+                }
+
+                FloatingActionButton(
+                    modifier =
+                    Modifier.align(Alignment.BottomStart)
+                        .padding(16.dp)
+                        .testTag("centerOnCurrentLocation"),
+                    onClick = {
+                        coroutineScope.launch {
+                            currentLocation?.let {
+                                val locationLatLng = LatLng(it.latitude, it.longitude)
+                                cameraPositionState.animate(
+                                    update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
+                                    durationMs = 800)
+                            }
+                        }
+                    }) {
+                    Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
+                }
+            }
+        },
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = Route.MAP)
+        })
+
+
+    if (showBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showBottomSheet = false },
+
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                // Ligne pour la croix en haut à droite
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Bouton "See more details" à gauche
+                    Button(
+                        onClick = {
+                            selectedActivity?.let { listActivitiesViewModel.selectActivity(it) }
+                            navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
+                            showBottomSheet = false
+                        },
+                    ) {
+                        Text("See more details")
+                    }
+
+                    // Icône de fermeture (croix) à droite
+                    IconButton(onClick = { showBottomSheet = false }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Fermer",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+                if (selectedActivity != null) {
+                    DisplayActivity(activity = selectedActivity!!)
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+
 }
+@Composable
+fun DisplayActivity(activity: Activity) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        // Image en haut
+        if (activity.images.isNotEmpty()) {
+            AsyncImage(
+                model = activity.images.first(),
+                contentDescription = "Image de l'activité",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        // Titre et description
+        Text(
+            text = activity.title,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = activity.description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Date et localisation
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(bottom = 8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.CalendarToday,
+                contentDescription = "Date",
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "Date: ${activity.date.toDate()}")
+        }
+        if (activity.location != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = "Lieu",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = "Lieu: ${activity.location!!.name}")
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Prix et places disponibles
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = "Prix: ${activity.price}€",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = "Places restantes: ${activity.placesLeft}/${activity.maxPlaces}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Participants
+
+    }
+}
+
+

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarToday
@@ -26,7 +25,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -47,7 +45,6 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.launch
-import org.junit.Test
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,259 +53,221 @@ fun MapScreen(
     locationViewModel: LocationViewModel,
     listActivitiesViewModel: ListActivitiesViewModel
 ) {
-    val context = LocalContext.current
-    val currentLocation by locationViewModel.currentLocation.collectAsState()
-    val coroutineScope = rememberCoroutineScope()
-    val activities by listActivitiesViewModel.uiState.collectAsState()
-    val defaultLocation = LatLng(46.519962, 6.633597) // EPFL
-    var selectedActivity by remember { mutableStateOf<Activity?>(null) }
-    var showBottomSheet by remember { mutableStateOf(false) }
+  val context = LocalContext.current
+  val currentLocation by locationViewModel.currentLocation.collectAsState()
+  val coroutineScope = rememberCoroutineScope()
+  val activities by listActivitiesViewModel.uiState.collectAsState()
+  val defaultLocation = LatLng(46.519962, 6.633597) // EPFL
+  var selectedActivity by remember { mutableStateOf<Activity?>(null) }
+  var showBottomSheet by remember { mutableStateOf(false) }
 
-    val firstToDoLocation =
-        try {
-            val loc =
+  val firstToDoLocation =
+      try {
+        val loc =
+            (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
+                .activities
+                .firstNotNullOf { it.location }
+        LatLng(loc.latitude, loc.longitude)
+      } catch (_: NoSuchElementException) {
+        defaultLocation
+      }
+  val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(firstToDoLocation, 10f)
+  }
+
+  // Activity result launcher to request permissions
+  val locationPermissionLauncher =
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.RequestPermission(),
+          onResult = { isGranted ->
+            if (isGranted) {
+              locationViewModel.fetchCurrentLocation()
+            } else {
+              Log.d("MapScreen", "Location permission denied by the user.")
+            }
+          })
+
+  LaunchedEffect(Unit) {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED) {
+      locationViewModel.fetchCurrentLocation()
+    } else {
+      locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+  }
+
+  Scaffold(
+      content = { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+          GoogleMap(
+              modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
+              cameraPositionState = cameraPositionState) {
                 (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
                     .activities
-                    .firstNotNullOf { it.location }
-            LatLng(loc.latitude, loc.longitude)
-        } catch (_: NoSuchElementException) {
-            defaultLocation
-        }
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(firstToDoLocation, 10f)
-    }
-
-    // Activity result launcher to request permissions
-    val locationPermissionLauncher =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission(),
-            onResult = { isGranted ->
-                if (isGranted) {
-                    locationViewModel.fetchCurrentLocation()
-                } else {
-                    Log.d("MapScreen", "Location permission denied by the user.")
-                }
-            })
-
-    LaunchedEffect(Unit) {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
-            PackageManager.PERMISSION_GRANTED) {
-            locationViewModel.fetchCurrentLocation()
-        } else {
-            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-        }
-    }
-
-    Scaffold(
-        content = { padding ->
-            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
-                    cameraPositionState = cameraPositionState) {
-                    (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
-                        .activities
-                        .filter { it.location != null }
-                        .forEach { item ->
-                            Marker(
-
-                                state =
-                                MarkerState(
-                                    position =
-                                    LatLng(item.location!!.latitude, item.location!!.longitude)),
-                                title = item.title,
-                                snippet = item.description,
-                                onClick = {
-                                    selectedActivity = item
-                                    selectedActivity?.let { listActivitiesViewModel.selectActivity(it) }
-                                    showBottomSheet = true
-                                    true
-                                }
-                            )
-                        }
-                    currentLocation?.let {
-                        Marker(
-                            state = rememberMarkerState(position = LatLng(it.latitude, it.longitude)),
-                            title = it.name,
-                            snippet = "Lat: ${it.latitude}, Lon: ${it.longitude}",
-                            icon =
-                            BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
+                    .filter { it.location != null }
+                    .forEach { item ->
+                      Marker(
+                          state =
+                              MarkerState(
+                                  position =
+                                      LatLng(item.location!!.latitude, item.location!!.longitude)),
+                          title = item.title,
+                          snippet = item.description,
+                          onClick = {
+                            selectedActivity = item
+                            selectedActivity?.let { listActivitiesViewModel.selectActivity(it) }
+                            showBottomSheet = true
+                            true
+                          })
                     }
+                currentLocation?.let {
+                  Marker(
+                      state = rememberMarkerState(position = LatLng(it.latitude, it.longitude)),
+                      title = it.name,
+                      snippet = "Lat: ${it.latitude}, Lon: ${it.longitude}",
+                      icon =
+                          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
                 }
+              }
 
-                FloatingActionButton(
-                    modifier =
-                    Modifier.align(Alignment.BottomStart)
-                        .padding(16.dp)
-                        .testTag("centerOnCurrentLocation"),
-                    onClick = {
-                        coroutineScope.launch {
-                            currentLocation?.let {
-                                val locationLatLng = LatLng(it.latitude, it.longitude)
-                                cameraPositionState.animate(
-                                    update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
-                                    durationMs = 800)
-                            }
-                        }
-                    }) {
-                    Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
+          FloatingActionButton(
+              modifier =
+                  Modifier.align(Alignment.BottomStart)
+                      .padding(16.dp)
+                      .testTag("centerOnCurrentLocation"),
+              onClick = {
+                coroutineScope.launch {
+                  currentLocation?.let {
+                    val locationLatLng = LatLng(it.latitude, it.longitude)
+                    cameraPositionState.animate(
+                        update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
+                        durationMs = 800)
+                  }
                 }
-            }
-        },
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = Route.MAP)
-        })
-
-
-    if (showBottomSheet) {
-        ModalBottomSheet(
-            onDismissRequest = { showBottomSheet = false },
-
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                // Ligne pour la croix en haut à droite
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-
-                    SeeMoreDetailsButton(navigationActions)
-
-                    // Icône de fermeture (croix) à droite
-                    IconButton(onClick = { showBottomSheet = false }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = "Close",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
-                if (selectedActivity != null) {
-                    DisplayActivity(activity = selectedActivity!!)
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-            }
+              }) {
+                Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
+              }
         }
-    }
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.MAP)
+      })
 
+  if (showBottomSheet) {
+    ModalBottomSheet(
+        onDismissRequest = { showBottomSheet = false },
+    ) {
+      Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        // Ligne pour la croix en haut à droite
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
+            verticalAlignment = Alignment.CenterVertically) {
+              SeeMoreDetailsButton(navigationActions)
+
+              // Icône de fermeture (croix) à droite
+              IconButton(onClick = { showBottomSheet = false }) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close",
+                    tint = MaterialTheme.colorScheme.onSurface)
+              }
+            }
+        if (selectedActivity != null) {
+          DisplayActivity(activity = selectedActivity!!)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+      }
+    }
+  }
 }
+
 @Composable
 fun DisplayActivity(activity: Activity) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp).testTag("activityDetails")
-    ) {
-        // Image en haut
-        if (activity.images.isNotEmpty()) {
-            AsyncImage(
-                model = activity.images.first(),
-                contentDescription = "Activity image",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .clip(RoundedCornerShape(12.dp)).testTag("activityImage"),
-                contentScale = ContentScale.Crop
-            )
-            Spacer(modifier = Modifier.height(12.dp))
+  Column(modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activityDetails")) {
+    // Image en haut
+    if (activity.images.isNotEmpty()) {
+      AsyncImage(
+          model = activity.images.first(),
+          contentDescription = "Activity image",
+          modifier =
+              Modifier.fillMaxWidth()
+                  .height(200.dp)
+                  .clip(RoundedCornerShape(12.dp))
+                  .testTag("activityImage"),
+          contentScale = ContentScale.Crop)
+      Spacer(modifier = Modifier.height(12.dp))
+    }
+
+    // Titre et description
+    Text(
+        text = activity.title,
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.padding(bottom = 8.dp).testTag("activityTitle"),
+    )
+    Text(
+        text = activity.description,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp).testTag("activityDescription"),
+    )
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(bottom = 8.dp).testTag("activityDate")) {
+          Icon(
+              imageVector = Icons.Default.CalendarToday,
+              contentDescription = "Date",
+              tint = MaterialTheme.colorScheme.primary,
+              modifier = Modifier.testTag("calendarIcon"))
+          Spacer(modifier = Modifier.width(8.dp))
+          Text(
+              text = "Date: ${activity.date.toDate()}", modifier = Modifier.testTag("calendarText"))
         }
-
-        // Titre et description
-        Text(
-            text = activity.title,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(bottom = 8.dp).testTag("activityTitle"),
-        )
-        Text(
-            text = activity.description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp).testTag("activityDescription"),
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(bottom = 8.dp).testTag("activityDate")
-        ) {
+    if (activity.location != null) {
+      Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.padding(bottom = 8.dp).testTag("activityLocation")) {
             Icon(
-                imageVector = Icons.Default.CalendarToday,
-                contentDescription = "Date",
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = "Location",
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.testTag("calendarIcon")
-            )
+                modifier = Modifier.testTag("locationIcon"))
             Spacer(modifier = Modifier.width(8.dp))
-            Text(text = "Date: ${activity.date.toDate()}",
-                modifier = Modifier.testTag("calendarText")
-            )
-        }
-        if (activity.location != null) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 8.dp).testTag("activityLocation")
-            ) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = "Location",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.testTag("locationIcon")
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(text = "Location: ${activity.location!!.name}",
-                    modifier = Modifier.testTag("locationText")
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(12.dp))
-
-
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth().testTag("activityPrice")
-        ) {
             Text(
-                text = "Price: ${activity.price}€",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("priceText")
-            )
-            Text(
-                text = "Places left: ${activity.placesLeft}/${activity.maxPlaces}",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("placesLeft")
-            )
-        }
-        Spacer(modifier = Modifier.height(12.dp))
-
-
-
+                text = "Location: ${activity.location!!.name}",
+                modifier = Modifier.testTag("locationText"))
+          }
     }
+    Spacer(modifier = Modifier.height(12.dp))
 
-
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxWidth().testTag("activityPrice")) {
+          Text(
+              text = "Price: ${activity.price}€",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.testTag("priceText"))
+          Text(
+              text = "Places left: ${activity.placesLeft}/${activity.maxPlaces}",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.testTag("placesLeft"))
+        }
+    Spacer(modifier = Modifier.height(12.dp))
+  }
 }
+
 @Composable
-
-fun SeeMoreDetailsButton(navigationActions: NavigationActions){
-    Button(
-        modifier = Modifier.testTag("seeMoreDetailsButton"),
-        onClick = {
-
-            navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
-
-        },
-    ) {
-        Text(text="See more details")
-    }
+fun SeeMoreDetailsButton(navigationActions: NavigationActions) {
+  Button(
+      modifier = Modifier.testTag("seeMoreDetailsButton"),
+      onClick = { navigationActions.navigateTo(Screen.ACTIVITY_DETAILS) },
+  ) {
+    Text(text = "See more details")
+  }
 }
-
-

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -161,14 +161,14 @@ fun MapScreen(
         onDismissRequest = { showBottomSheet = false },
     ) {
       Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-        // Ligne pour la croix en haut à droite
+
         Row(
             modifier = Modifier.fillMaxWidth().padding(8.dp),
             horizontalArrangement = Arrangement.SpaceBetween, // Espace entre les éléments
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
 
-              // Icône de fermeture (croix) à droite
+
               IconButton(onClick = { showBottomSheet = false }) {
                 Icon(
                     imageVector = Icons.Default.Close,


### PR DESCRIPTION

### **Pull Request:** Add Activity Details Preview on the map

#### **Summary**
This pull request introduces a feature to display an activity details preview when interacting with a map marker. It also includes  adding comprehensive tests to ensure functionality.

---

### **Feature: Add Activity Details Preview on Map**
- **Activity Details Preview**: 
  - Displays key information when clicking on a marker, including:
    - First image of the activity
    - Title of the activity
    - Description of the activity
    - Price of the activity
    - Date and time of the activity
    - Exact location of the activity
    - Number of places left
  - Adds functionality to navigate to the activity details screen by clicking the "See More Details" button.
  - Provides the ability to close the preview by:
    - Clicking the close icon button.
    - Performing a dismiss request.

---



### **Tests: Add Comprehensive Test Coverage**
- **Activity Details Display Test**: Verifies that the following components are displayed in the activity details:
  - Title
  - Description
  - Date
  - Location
  - Price
  - Number of places left
- **"See More Details" Button Test**:
  - Verifies the existence of the button.
  - Asserts navigation to the activity details screen upon click.

---
### Screenshot of the bottom sheet that is displayed when clicking on a marker
![image](https://github.com/user-attachments/assets/f0a2b8c0-d98c-4815-ae39-f64548de8271)

### Notes:
-  The other elements are really hard to test since they interact with the map and the markers which are difficult to test.


--- 

Let me know if you’d like to add or modify any details!

