### PR TITLE
Enhance the MVVM Implementation of the sign-in

### DIFF
--- a/app/src/main/java/com/android/sample/model/auth/SignInRepository.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInRepository.kt
@@ -1,19 +1,11 @@
 package com.android.sample.model.auth
 
-import com.android.sample.ui.navigation.NavigationActions
 import com.google.firebase.auth.AuthResult
 
 interface SignInRepository {
   suspend fun signInWithEmail(email: String, password: String): AuthResult
 
   suspend fun signInWithGoogle(idToken: String): AuthResult
-
-  fun checkUserProfile(
-      uid: String?,
-      navigationActions: NavigationActions,
-      onAuthSuccess: () -> Unit,
-      onAuthError: (String) -> Unit
-  )
 
   fun signOut()
 }

--- a/app/src/main/java/com/android/sample/model/auth/SignInRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInRepositoryFirebase.kt
@@ -1,9 +1,6 @@
 package com.android.sample.model.auth
 
-import android.util.Log
 import com.android.sample.model.profile.ProfilesRepository
-import com.android.sample.ui.navigation.NavigationActions
-import com.android.sample.ui.navigation.Screen
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
@@ -21,35 +18,6 @@ constructor(private val auth: FirebaseAuth, private val profilesRepository: Prof
   override suspend fun signInWithGoogle(idToken: String): AuthResult {
     val credential = GoogleAuthProvider.getCredential(idToken, null)
     return auth.signInWithCredential(credential).await()
-  }
-
-  override fun checkUserProfile(
-      uid: String?,
-      navigationActions: NavigationActions,
-      onAuthSuccess: () -> Unit,
-      onAuthError: (String) -> Unit
-  ) {
-    if (uid == null) {
-      onAuthError("User ID is null, cannot proceed!")
-      return
-    }
-
-    profilesRepository.getUser(
-        uid,
-        onSuccess = { userProfile ->
-          if (userProfile == null) {
-            Log.d("SignInRepository", "No user profile found for user ID: $uid")
-            navigationActions.navigateTo(Screen.CREATE_PROFILE)
-          } else {
-            Log.d("SignInRepository", "User profile found for user ID: $uid")
-            navigationActions.navigateTo(Screen.OVERVIEW)
-          }
-          onAuthSuccess()
-        },
-        onFailure = {
-          onAuthError("Error checking user profile!")
-          Log.e("SignInRepository", "Error checking user profile: ${it.message}")
-        })
   }
 
   override fun signOut() {

--- a/app/src/test/java/com/android/sample/model/profile/MockProfilesRepository.kt
+++ b/app/src/test/java/com/android/sample/model/profile/MockProfilesRepository.kt
@@ -1,0 +1,89 @@
+package com.android.sample.model.profile
+
+class MockProfilesRepository : ProfilesRepository {
+
+  private val userProfiles =
+      mutableMapOf<String, User>(
+          "u1" to
+              User(
+                  id = "u1",
+                  name = "Alice",
+                  surname = "Smith",
+                  interests = listOf("Hiking", "Cycling"),
+                  activities = listOf("a1", "a2"),
+                  photo = null,
+                  likedActivities = listOf("a1")))
+  private val activitiesList =
+      mutableMapOf<String, MutableList<String>>("u1" to mutableListOf("a1", "a2"))
+
+  override fun getUser(userId: String, onSuccess: (User?) -> Unit, onFailure: (Exception) -> Unit) {
+    try {
+      // Retrieve the user profile by userId
+      val user = userProfiles[userId]
+      onSuccess(user)
+    } catch (e: Exception) {
+      onFailure(e)
+    }
+  }
+
+  override fun addActivity(
+      userId: String,
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      // Add activity to user's activity list
+      if (userProfiles.containsKey(userId)) {
+        activitiesList.computeIfAbsent(userId) { mutableListOf() }.add(activityId)
+        onSuccess()
+      } else {
+        throw Exception("User not found")
+      }
+    } catch (e: Exception) {
+      onFailure(e)
+    }
+  }
+
+  override fun addLikedActivity(
+      userId: String,
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    TODO("Not yet implemented")
+  }
+
+  override fun removeLikedActivity(
+      userId: String,
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    TODO("Not yet implemented")
+  }
+
+  override fun updateProfile(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    try {
+      // Update the user profile in the in-memory map
+      userProfiles[user.id] = user
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+    }
+  }
+
+  override fun addProfileToDatabase(
+      userProfile: User,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      // Simulate adding a user profile to the database
+      userProfiles[userProfile.id] = userProfile
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+    }
+  }
+}


### PR DESCRIPTION
In this PR I did a lot of refactors and feature adjustments to improve the structure and maintainability of the sign-in, specifically focusing on the checkUserProfile function and related components. 
###  Why I have done this?
- Improve separation of concerns in the sign-in code. 
- Moving checkUserProfile to the SignInViewModel as a private function makes it easier to use, and especially to test
- This new refactor will help us have easier mocking with hilt