### PR TITLE
Disable button/database interactions when user is not connected to the network

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -401,7 +401,12 @@ fun ActivityDetailsScreen(
                 } else {
                   // Creator of the activity
                   Button(
-                      onClick = { navigationActions.navigateTo(Screen.EDIT_ACTIVITY) },
+                      onClick = {
+                        performOfflineAwareAction(
+                            context = context,
+                            networkManager = networkManager,
+                            onPerform = { navigationActions.navigateTo(Screen.EDIT_ACTIVITY) })
+                      },
                       modifier =
                           Modifier.fillMaxWidth()
                               .padding(horizontal = LARGE_PADDING.dp)

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.profile
 
+import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -247,14 +248,14 @@ fun ActivityBox(
   val uiState by listActivitiesViewModel.uiState.collectAsState()
   val activitiesList = (uiState as ListActivitiesViewModel.ActivitiesUiState.Success).activities
   val thisActivity = activitiesList.find { it.uid == activityId }
-
+  val context = LocalContext.current
   thisActivity?.let { activity ->
     if (shouldShowActivity(activity, user, category)) {
       ActivityRow(
           activity = activity,
           onClickAction = {
             listActivitiesViewModel.selectActivity(activity)
-            navigateToActivity(category, navigationActions)
+            navigateToActivity(category, navigationActions, context)
           },
           testTag = "activity${category.capitalize()}")
     }
@@ -271,10 +272,19 @@ fun shouldShowActivity(activity: Activity, user: User, category: String): Boolea
   }
 }
 /** Navigate to the appropriate screen based on the category */
-fun navigateToActivity(category: String, navigationActions: NavigationActions) {
+fun navigateToActivity(category: String, navigationActions: NavigationActions, context: Context) {
+  val networkManager = NetworkManager(context)
   when (category) {
-    "created" -> navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
-    "past" -> navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
+    "created" ->
+        performOfflineAwareAction(
+            context,
+            networkManager,
+            onPerform = { navigationActions.navigateTo(Screen.EDIT_ACTIVITY) })
+    "past" ->
+        performOfflineAwareAction(
+            context,
+            networkManager,
+            onPerform = { navigationActions.navigateTo(Screen.EDIT_ACTIVITY) })
     "enrolled" -> navigationActions.navigateTo(Screen.ACTIVITY_DETAILS)
   }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import com.android.sample.R
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.network.NetworkManager
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
@@ -39,6 +41,7 @@ import com.android.sample.resources.C.Tag.TEXT_FONTSIZE
 import com.android.sample.resources.C.Tag.TITLE_FONTSIZE
 import com.android.sample.resources.C.Tag.TOP_TITLE_SIZE
 import com.android.sample.ui.camera.ProfileImage
+import com.android.sample.ui.components.performOfflineAwareAction
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.sample.ui.navigation.NavigationActions
@@ -97,6 +100,8 @@ fun ProfileContent(
     listActivitiesViewModel: ListActivitiesViewModel,
     userProfileViewModel: ProfileViewModel
 ) {
+  val context = LocalContext.current
+  val networkManager = NetworkManager(context)
   var showMenu by remember { mutableStateOf(false) }
   Log.d("ProfileScreen", "User photo: ${user.photo}")
   Scaffold(
@@ -129,10 +134,15 @@ fun ProfileContent(
                 DropdownMenuItem(
                     text = { Text("Logout") },
                     onClick = {
-                      showMenu = false
-                      userProfileViewModel.clearUserData()
-                      Firebase.auth.signOut()
-                      navigationActions.navigateTo(Screen.AUTH)
+                      performOfflineAwareAction(
+                          context = context,
+                          networkManager = networkManager,
+                          onPerform = {
+                            showMenu = false
+                            userProfileViewModel.clearUserData()
+                            Firebase.auth.signOut()
+                            navigationActions.navigateTo(Screen.AUTH)
+                          })
                     },
                     enabled = Firebase.auth.currentUser?.isAnonymous == false)
               }


### PR DESCRIPTION
In this PR, I tried to find all the buttons that may interact with the database to disable them using the previously created function performOfflineAwareAction so that there is no uncoherency between what we see in the screen and what happens in the databse, for example:

- The "Save Changes" button in the Profile Screen is now disabled when the phone is offline. Previously, users could click the button, leading to no updates in the database due to the lack of network connectivity, causing confusion.
- Buttons to enroll or leave activities in the Overview or Activity Details screen are wrapped with performOfflineAwareAction. When offline, the buttons are disabled and provide feedback via a toast, preventing users from attempting actions that won't sync with the database.

**How to Test**
- Run the app and navigate to the affected screens.
- Simulate offline mode by disabling the device's network connection.
- Validate that:
   - Database interactions are blocked with appropriate feedback.
   - Navigation to restricted screens is prevented with user notifications.
   - Existing functionality (e.g., data viewing) remains unaffected in offline mode.