### PR TITLE
Change the Icon on Edit Activity Screen for starting time

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.HourglassTop
 import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
@@ -258,7 +259,7 @@ fun EditActivityScreen(
                         .testTag("changeTimeButton"),
             ) {
               Icon(
-                  Icons.Default.CalendarMonth,
+                  Icons.Default.Schedule,
                   contentDescription = "Change Time",
                   modifier = Modifier.testTag("changeTimeIcon"),
               )


### PR DESCRIPTION
This pull request includes changes to the `EditActivity.kt` file to update the icon used for the "Change Time" button.

Icon Update:

* [`app/src/main/java/com/android/sample/ui/activity/EditActivity.kt`](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144L261-R262): Replaced the `CalendarMonth` icon with the `Schedule` icon for the "Change Time" button.
* [`app/src/main/java/com/android/sample/ui/activity/EditActivity.kt`](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144R28): Imported the `Schedule` icon from `androidx.compose.material.icons.filled`.