### PR TITLE
Feature/type filtering in dialog

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -286,7 +286,6 @@ class CreateActivityScreenTest {
     composeTestRule.onNodeWithTag("chooseTypeMenu").assertIsDisplayed()
     composeTestRule.onNodeWithText(types[0].name).assertIsDisplayed()
     composeTestRule.onNodeWithText(types[1].name).assertIsDisplayed()
-
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -350,7 +350,6 @@ class CreateActivityScreenTest {
     composeTestRule.onNodeWithTag("chooseTypeMenu").assertIsDisplayed()
     composeTestRule.onNodeWithText(categories[0].name).assertIsDisplayed()
     composeTestRule.onNodeWithText(categories[1].name).assertIsDisplayed()
-    composeTestRule.onNodeWithText(categories[2].name).assertIsDisplayed()
   }
 
   @Test
@@ -384,12 +383,6 @@ class CreateActivityScreenTest {
     composeTestRule.onNodeWithText(types[1].name).assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("chooseTypeMenu").performClick()
-
-    // Click on the first item in the dropdown
-    composeTestRule.onNodeWithText(types[2].name).performClick()
-
-    // Verify that the selected option is now displayed in the TextField
-    composeTestRule.onNodeWithText(types[2].name).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/CreateActivityScreenTest.kt
@@ -331,7 +331,7 @@ class CreateActivityScreenTest {
     composeTestRule.onNodeWithTag("chooseTypeMenu").assertIsDisplayed()
     composeTestRule.onNodeWithText(types[0].name).assertIsDisplayed()
     composeTestRule.onNodeWithText(types[1].name).assertIsDisplayed()
-    composeTestRule.onNodeWithText(types[2].name).assertIsDisplayed()
+
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -18,7 +18,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldDisplayAllComponents() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
 
     composeTestRule.onNodeWithTag("FilterDialog").assertIsDisplayed()
     composeTestRule.onNodeWithText("Price Range").assertIsDisplayed()
@@ -48,7 +48,7 @@ class FilterDialogTest {
   */
   @Test
   fun filterDialog_shouldUpdateMembersAvailable() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
 
     val inputText = "10"
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput(inputText)
@@ -59,7 +59,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldSetStartDate() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
 
     val startDate = "15/09/2024"
     composeTestRule.onNodeWithTag("minDateTextField").performTextInput(startDate)
@@ -70,7 +70,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldSetDuration() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
 
     val duration = "2 hours"
     composeTestRule.onNodeWithTag("durationTextField").performTextInput(duration)
@@ -84,7 +84,7 @@ class FilterDialogTest {
     var dismissed = false
 
     composeTestRule.setContent {
-      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _ -> })
+      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _, _ -> })
     }
 
     // Perform click on Cancel
@@ -105,7 +105,7 @@ class FilterDialogTest {
     composeTestRule.setContent {
       FilterDialog(
           onDismiss = {},
-          onFilter = { price, members, date, dur ->
+          onFilter = { price, members, date, dur, _ ->
             filterCalled = true
             maxPrice = price
             membersAvailable = members

--- a/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
@@ -582,34 +582,31 @@ class OverviewScreenTest {
     composeTestRule.onNodeWithText("Short activity").assertIsDisplayed()
     composeTestRule.onNodeWithText("Long activity").assertIsDisplayed()
   }
-    @Test
-    fun filterDialogFiltersByOnlyPRO() {
-        userProfileViewModel = mock(ProfileViewModel::class.java)
-        `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
-        composeTestRule.setContent {
-            ListActivitiesScreen(
-                listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
-        }
 
-        val activity1 = activity.copy(title = "PRO activity", type = ActivityType.PRO)
-        val activity2 = activity.copy(title = "INDIVIDUAL activity", type = ActivityType.INDIVIDUAL)
-
-        `when`(activitiesRepository.getActivities(any(), any())).then {
-            it.getArgument<(List<Activity>) -> Unit>(0)(listOf(activity1, activity2))
-        }
-
-        listActivitiesViewModel.getActivities()
-
-        composeTestRule.onNodeWithTag("filterDialog").performClick()
-        composeTestRule.onNodeWithTag("onlyPROCheckboxRow").assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag("onlyPROCheckbox")
-            .performClick()
-        composeTestRule.onNodeWithTag("filterButton").performClick()
-
-        composeTestRule.onNodeWithText("PRO activity").assertIsDisplayed()
-        composeTestRule.onNodeWithText("INDIVIDUAL activity").assertDoesNotExist()
+  @Test
+  fun filterDialogFiltersByOnlyPRO() {
+    userProfileViewModel = mock(ProfileViewModel::class.java)
+    `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+    composeTestRule.setContent {
+      ListActivitiesScreen(
+          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
     }
 
-}
+    val activity1 = activity.copy(title = "PRO activity", type = ActivityType.PRO)
+    val activity2 = activity.copy(title = "INDIVIDUAL activity", type = ActivityType.INDIVIDUAL)
 
+    `when`(activitiesRepository.getActivities(any(), any())).then {
+      it.getArgument<(List<Activity>) -> Unit>(0)(listOf(activity1, activity2))
+    }
+
+    listActivitiesViewModel.getActivities()
+
+    composeTestRule.onNodeWithTag("filterDialog").performClick()
+    composeTestRule.onNodeWithTag("onlyPROCheckboxRow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("onlyPROCheckbox").performClick()
+    composeTestRule.onNodeWithTag("filterButton").performClick()
+
+    composeTestRule.onNodeWithText("PRO activity").assertIsDisplayed()
+    composeTestRule.onNodeWithText("INDIVIDUAL activity").assertDoesNotExist()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
@@ -601,6 +601,7 @@ class OverviewScreenTest {
         listActivitiesViewModel.getActivities()
 
         composeTestRule.onNodeWithTag("filterDialog").performClick()
+        composeTestRule.onNodeWithTag("onlyPROCheckboxRow").assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("onlyPROCheckbox")
             .performClick()

--- a/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
@@ -413,7 +413,7 @@ class OverviewScreenTest {
           listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
     }
     val activity1 = activity.copy(title = "cooking", type = ActivityType.INDIVIDUAL)
-    val activity2 = activity.copy(title = "dance", type = ActivityType.SOLO)
+    val activity2 = activity.copy(title = "dance", type = ActivityType.PRO)
     val activity3 = activity.copy(title = "football", type = ActivityType.INDIVIDUAL)
 
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -437,7 +437,7 @@ class OverviewScreenTest {
           listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
     }
     val activity1 = activity.copy(title = "cooking", type = ActivityType.INDIVIDUAL)
-    val activity2 = activity.copy(title = "dance", type = ActivityType.SOLO)
+    val activity2 = activity.copy(title = "dance", type = ActivityType.PRO)
     val activity3 = activity.copy(title = "football", type = ActivityType.INDIVIDUAL)
 
     `when`(activitiesRepository.getActivities(any(), any())).then {

--- a/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
@@ -582,4 +582,33 @@ class OverviewScreenTest {
     composeTestRule.onNodeWithText("Short activity").assertIsDisplayed()
     composeTestRule.onNodeWithText("Long activity").assertIsDisplayed()
   }
+    @Test
+    fun filterDialogFiltersByOnlyPRO() {
+        userProfileViewModel = mock(ProfileViewModel::class.java)
+        `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
+        composeTestRule.setContent {
+            ListActivitiesScreen(
+                listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+        }
+
+        val activity1 = activity.copy(title = "PRO activity", type = ActivityType.PRO)
+        val activity2 = activity.copy(title = "INDIVIDUAL activity", type = ActivityType.INDIVIDUAL)
+
+        `when`(activitiesRepository.getActivities(any(), any())).then {
+            it.getArgument<(List<Activity>) -> Unit>(0)(listOf(activity1, activity2))
+        }
+
+        listActivitiesViewModel.getActivities()
+
+        composeTestRule.onNodeWithTag("filterDialog").performClick()
+        composeTestRule
+            .onNodeWithTag("onlyPROCheckbox")
+            .performClick()
+        composeTestRule.onNodeWithTag("filterButton").performClick()
+
+        composeTestRule.onNodeWithText("PRO activity").assertIsDisplayed()
+        composeTestRule.onNodeWithText("INDIVIDUAL activity").assertDoesNotExist()
+    }
+
 }
+

--- a/app/src/main/java/com/android/sample/model/activity/ActivitiesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/activity/ActivitiesRepositoryFirestore.kt
@@ -78,9 +78,9 @@ open class ActivitiesRepositoryFirestore @Inject constructor(private val db: Fir
           try {
             ActivityType.valueOf(it as String)
           } catch (e: IllegalArgumentException) {
-            ActivityType.SOLO
+            ActivityType.INDIVIDUAL
           }
-        } ?: ActivityType.SOLO
+        } ?: ActivityType.INDIVIDUAL
     val comments =
         (data["comments"] as? List<Map<String, Any>>)?.map { commentData ->
           Comment(

--- a/app/src/main/java/com/android/sample/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/sample/model/activity/Activity.kt
@@ -36,7 +36,6 @@ data class Comment(
 enum class ActivityType {
   PRO,
   INDIVIDUAL,
-  SOLO,
 }
 
 val types = ActivityType.values().toList()

--- a/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/DummyData.kt
@@ -270,7 +270,7 @@ val validData =
         "placesLeft" to 5L,
         "maxPlaces" to 20L,
         "status" to "ACTIVE",
-        "type" to "SOLO",
+        "type" to "INDIVIDUAL",
         "participants" to
             listOf(
                 mapOf(

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -28,13 +28,15 @@ import com.google.firebase.Timestamp
 fun FilterDialog(
     onDismiss: () -> Unit,
     onFilter:
-        (price: Double?, membersAvailable: Int?, schedule: Timestamp?, duration: String?) -> Unit
+        (price: Double?, membersAvailable: Int?, schedule: Timestamp?, duration: String?, onlyPRO: Boolean?) -> Unit,
+
 ) {
   var maxPrice by remember { mutableStateOf(DEFAULT_MAX_PRICE) }
   var availablePlaces by remember { mutableStateOf<Int?>(null) }
   var minDate by remember { mutableStateOf<String?>(null) }
   var minDateTimestamp by remember { mutableStateOf<Timestamp?>(null) }
   var duration by remember { mutableStateOf<String?>(null) }
+  var onlyPRO by remember { mutableStateOf<Boolean?>(false) }
 
   Dialog(
       onDismissRequest = { onDismiss() },
@@ -103,12 +105,31 @@ fun FilterDialog(
                     modifier = Modifier.testTag("durationTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
                 Spacer(modifier = Modifier.height(MEDIUM_PADDING.dp))
+              Row( modifier = Modifier.fillMaxWidth()) {
+                  Row(
+                      verticalAlignment = Alignment.CenterVertically,
+                  ) {
+
+                      Checkbox(
+                          checked = onlyPRO ?: false,
+                          onCheckedChange = { onlyPRO = it },
+                          colors = CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary),
+                      )
+                      Text(
+                           "Only see PRO activities",
+                      )
+                  }
+
+
+              }
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
                   TextButton(
                       onClick = { onDismiss() }, modifier = Modifier.testTag("cancelButton")) {
                         Text("Cancel")
                       }
+
                   Spacer(modifier = Modifier.width(SMALL_PADDING.dp))
+
                   Button(
                       onClick = {
                         if (minDate != null) {
@@ -123,7 +144,7 @@ fun FilterDialog(
                               0)
                           minDateTimestamp = Timestamp(calendar.time)
                         }
-                        onFilter(maxPrice.toDouble(), availablePlaces, minDateTimestamp, duration)
+                        onFilter(maxPrice.toDouble(), availablePlaces, minDateTimestamp, duration,onlyPRO)
                         onDismiss()
                       },
                       modifier = Modifier.testTag("filterButton")) {

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -112,6 +112,7 @@ fun FilterDialog(
                 Row(modifier = Modifier.fillMaxWidth()) {
                   Row(
                       verticalAlignment = Alignment.CenterVertically,
+                      modifier= Modifier.testTag("onlyPROCheckboxRow")
 
                   ) {
                     Checkbox(

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -112,8 +112,10 @@ fun FilterDialog(
                 Row(modifier = Modifier.fillMaxWidth()) {
                   Row(
                       verticalAlignment = Alignment.CenterVertically,
+
                   ) {
                     Checkbox(
+                        modifier = Modifier.testTag("onlyPROCheckbox"),
                         checked = onlyPRO ?: false,
                         onCheckedChange = { onlyPRO = it },
                         colors =

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -28,8 +28,12 @@ import com.google.firebase.Timestamp
 fun FilterDialog(
     onDismiss: () -> Unit,
     onFilter:
-        (price: Double?, membersAvailable: Int?, schedule: Timestamp?, duration: String?, onlyPRO: Boolean?) -> Unit,
-
+        (
+            price: Double?,
+            membersAvailable: Int?,
+            schedule: Timestamp?,
+            duration: String?,
+            onlyPRO: Boolean?) -> Unit,
 ) {
   var maxPrice by remember { mutableStateOf(DEFAULT_MAX_PRICE) }
   var availablePlaces by remember { mutableStateOf<Int?>(null) }
@@ -105,23 +109,21 @@ fun FilterDialog(
                     modifier = Modifier.testTag("durationTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
                 Spacer(modifier = Modifier.height(MEDIUM_PADDING.dp))
-              Row( modifier = Modifier.fillMaxWidth()) {
+                Row(modifier = Modifier.fillMaxWidth()) {
                   Row(
                       verticalAlignment = Alignment.CenterVertically,
                   ) {
-
-                      Checkbox(
-                          checked = onlyPRO ?: false,
-                          onCheckedChange = { onlyPRO = it },
-                          colors = CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary),
-                      )
-                      Text(
-                           "Only see PRO activities",
-                      )
+                    Checkbox(
+                        checked = onlyPRO ?: false,
+                        onCheckedChange = { onlyPRO = it },
+                        colors =
+                            CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary),
+                    )
+                    Text(
+                        "Only see PRO activities",
+                    )
                   }
-
-
-              }
+                }
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
                   TextButton(
                       onClick = { onDismiss() }, modifier = Modifier.testTag("cancelButton")) {
@@ -144,7 +146,12 @@ fun FilterDialog(
                               0)
                           minDateTimestamp = Timestamp(calendar.time)
                         }
-                        onFilter(maxPrice.toDouble(), availablePlaces, minDateTimestamp, duration,onlyPRO)
+                        onFilter(
+                            maxPrice.toDouble(),
+                            availablePlaces,
+                            minDateTimestamp,
+                            duration,
+                            onlyPRO)
                         onDismiss()
                       },
                       modifier = Modifier.testTag("filterButton")) {

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -112,20 +112,19 @@ fun FilterDialog(
                 Row(modifier = Modifier.fillMaxWidth()) {
                   Row(
                       verticalAlignment = Alignment.CenterVertically,
-                      modifier= Modifier.testTag("onlyPROCheckboxRow")
-
-                  ) {
-                    Checkbox(
-                        modifier = Modifier.testTag("onlyPROCheckbox"),
-                        checked = onlyPRO ?: false,
-                        onCheckedChange = { onlyPRO = it },
-                        colors =
-                            CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary),
-                    )
-                    Text(
-                        "Only see PRO activities",
-                    )
-                  }
+                      modifier = Modifier.testTag("onlyPROCheckboxRow")) {
+                        Checkbox(
+                            modifier = Modifier.testTag("onlyPROCheckbox"),
+                            checked = onlyPRO ?: false,
+                            onCheckedChange = { onlyPRO = it },
+                            colors =
+                                CheckboxDefaults.colors(
+                                    checkedColor = MaterialTheme.colors.primary),
+                        )
+                        Text(
+                            "Only see PRO activities",
+                        )
+                      }
                 }
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
                   TextButton(

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -58,8 +58,10 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import com.android.sample.R
 import com.android.sample.model.activity.Activity
+import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.activity.categories
+import com.android.sample.model.activity.types
 import com.android.sample.model.map.LocationViewModel
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
@@ -99,6 +101,7 @@ fun ListActivitiesScreen(
   var availablePlaces by remember { mutableStateOf<Int?>(null) }
   var minDate by remember { mutableStateOf<Timestamp?>(null) }
   var duration by remember { mutableStateOf<String?>(null) }
+    var onlyPRO by remember { mutableStateOf(false) }
 
   val locationPermissionLauncher =
       rememberLauncherForActivityResult(
@@ -145,11 +148,14 @@ fun ListActivitiesScreen(
           if (showFilterDialog) {
             FilterDialog(
                 onDismiss = { showFilterDialog = false },
-                onFilter = { price, placesAvailable, mindateTimestamp, acDuration ->
+                onFilter = { price, placesAvailable, mindateTimestamp, acDuration, seeOnlyPRO ->
                   maxPrice = price?.toDouble() ?: 30000.0
                   availablePlaces = placesAvailable
                   minDate = mindateTimestamp
                   duration = acDuration
+                    if (seeOnlyPRO != null) {
+                        onlyPRO = seeOnlyPRO
+                    }
                 })
           }
           Box(
@@ -217,6 +223,7 @@ fun ListActivitiesScreen(
                             false
                         else if (minDate != null && it.date < minDate!!) false
                         else if (duration != null && it.duration != duration) false
+                        else if(onlyPRO && it.type!= ActivityType.PRO) false
                         else {
                           if (searchText.isEmpty() || searchText.isBlank()) true
                           else {

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -61,7 +61,6 @@ import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.activity.categories
-import com.android.sample.model.activity.types
 import com.android.sample.model.map.LocationViewModel
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
@@ -101,7 +100,7 @@ fun ListActivitiesScreen(
   var availablePlaces by remember { mutableStateOf<Int?>(null) }
   var minDate by remember { mutableStateOf<Timestamp?>(null) }
   var duration by remember { mutableStateOf<String?>(null) }
-    var onlyPRO by remember { mutableStateOf(false) }
+  var onlyPRO by remember { mutableStateOf(false) }
 
   val locationPermissionLauncher =
       rememberLauncherForActivityResult(
@@ -153,9 +152,9 @@ fun ListActivitiesScreen(
                   availablePlaces = placesAvailable
                   minDate = mindateTimestamp
                   duration = acDuration
-                    if (seeOnlyPRO != null) {
-                        onlyPRO = seeOnlyPRO
-                    }
+                  if (seeOnlyPRO != null) {
+                    onlyPRO = seeOnlyPRO
+                  }
                 })
           }
           Box(
@@ -223,7 +222,7 @@ fun ListActivitiesScreen(
                             false
                         else if (minDate != null && it.date < minDate!!) false
                         else if (duration != null && it.duration != duration) false
-                        else if(onlyPRO && it.type!= ActivityType.PRO) false
+                        else if (onlyPRO && it.type != ActivityType.PRO) false
                         else {
                           if (searchText.isEmpty() || searchText.isBlank()) true
                           else {

--- a/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/activities/ActivitiesRepositoryFirestoreTest.kt
@@ -211,7 +211,7 @@ class ActivitiesRepositoryFirestoreTest {
     assertEquals(5L, result.placesLeft)
     assertEquals(20L, result.maxPlaces)
     assertEquals(ActivityStatus.ACTIVE, result.status)
-    assertEquals(ActivityType.SOLO, result.type)
+    assertEquals(ActivityType.INDIVIDUAL, result.type)
     assertEquals(1, result.participants.size)
     assertEquals("John", result.participants.first().name)
     assertEquals(1, result.comments.size)
@@ -237,6 +237,6 @@ class ActivitiesRepositoryFirestoreTest {
     assertTrue(result.comments.isEmpty())
     assertEquals("No Location", result.location!!.name)
     assertEquals(ActivityStatus.ACTIVE, result.status)
-    assertEquals(ActivityType.SOLO, result.type)
+    assertEquals(ActivityType.INDIVIDUAL, result.type)
   }
 }


### PR DESCRIPTION
### **Add "Only See PRO Activities" Filter and Remove SOLO Activity Type**  

#### **Summary**  
This pull request introduces a new filter option to display only **PRO** activities, removes the **SOLO** activity type, and updates the associated logic and tests to align with these changes. Minor code refactoring for formatting is also included.  

---

#### **Key Features**  

1. **"Only See PRO Activities" Checkbox**  
   - Added a checkbox in the filter dialog for users to filter activities exclusively by the **PRO** type.  
   - Updated the filtering logic to accommodate this new option.  

2. **Remove SOLO Activity Type**  
   - The **SOLO** activity type has been removed from the codebase.  
   - Updated tests and filtering mechanisms to exclude references to **SOLO** activities.  

3. **Test**  
   - Added and improved tests to verify the "Only See PRO Activities" filter functionality.  
   - Ensured existing tests work correctly with the removal of the SOLO type.  

---
#### **Testing**  
- **Unit Tests:**  
  - Verified the "Only See PRO Activities" checkbox functionality.  
  - Ensured filtering logic adapts correctly with the absence of the SOLO type.  




