### PR TITLE
add filterDialog to mapScreen which is synchronised with the filter dialog in the overview of the app.

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt
@@ -104,4 +104,20 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag("seeMoreDetailsButton").performClick()
     verify(navigationActions).navigateTo(Screen.ACTIVITY_DETAILS)
   }
+
+  @Test
+  fun testFilterFabOpensFilterDialog() {
+    composeTestRule.setContent {
+      MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
+    }
+
+    // Check if the filter FAB is displayed
+    composeTestRule.onNodeWithTag("filterDialogButton").assertIsDisplayed()
+
+    // Perform click on the filter FAB
+    composeTestRule.onNodeWithTag("filterDialogButton").performClick()
+
+    // Check if the filter dialog is displayed
+    composeTestRule.onNodeWithTag("FilterDialog").assertIsDisplayed()
+  }
 }


### PR DESCRIPTION
This pull request includes changes to the `MapScreen` functionality in the Android application. The changes add a new feature to filter activities on the map screen and include corresponding test cases.

New feature implementation:

* [`app/src/main/java/com/android/sample/ui/map/Map.kt`](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R95): Introduced a Floating Action Button (FAB) to open a filter dialog, added state management for the filter dialog, and implemented the filtering logic in the mapScreen based on the user's criteria. [[1]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R95) [[2]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8L142-R161) [[3]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R205-R212) [[4]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8L195-R229)

Test case addition:

* [`app/src/androidTest/java/com/android/sample/ui/map/MapScreenTest.kt`](diffhunk://#diff-096058bbef3fa8eecbe1de0e657521b65b4f975c89284932a0ba6ab6dcafc5a6R107-R122): Added a new test case to verify that the filter FAB opens the filter dialog.

