### PR TITLE
Fix/fix navigation from profile

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/profile/ParticipantProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ParticipantProfileScreenTest.kt
@@ -14,9 +14,11 @@ import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.image.ImageRepositoryFirestore
 import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.profile.Interest
+import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.model.profile.User
 import com.android.sample.resources.dummydata.listOfActivitiesUid
+import com.android.sample.resources.dummydata.testUser
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import org.junit.Before
@@ -28,10 +30,12 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 
 class ParticipantProfileScreenTest {
+
+  private lateinit var userProfileViewModel: ProfileViewModel
+  private lateinit var testUser: User
   private lateinit var activitiesRepository: ActivitiesRepositoryFirestore
   private lateinit var listActivitiesViewModel: ListActivitiesViewModel
   private lateinit var navigationActions: NavigationActions
-  private lateinit var testUser: User
   private lateinit var mockImageViewModel: ImageViewModel
   private lateinit var mockImageRepository: ImageRepositoryFirestore
 
@@ -40,7 +44,17 @@ class ParticipantProfileScreenTest {
   @Before
   fun setUp() {
     // Mock dependencies
-
+    testUser =
+        User(
+            id = "Rola",
+            name = "Amine",
+            surname = "A",
+            photo = "",
+            interests =
+                listOf(Interest("Sport", "Cycling"), Interest("Indoor Activity", "Reading")),
+            activities = listOfActivitiesUid,
+        )
+    userProfileViewModel = mock(ProfileViewModel::class.java)
     navigationActions = mock(NavigationActions::class.java)
     activitiesRepository = mock(ActivitiesRepositoryFirestore::class.java)
     listActivitiesViewModel =
@@ -49,16 +63,6 @@ class ParticipantProfileScreenTest {
       it.getArgument<(List<Activity>) -> Unit>(0)(
           com.android.sample.resources.dummydata.activityListWithPastActivity)
     }
-    // Set up test user
-    testUser =
-        User(
-            id = "123",
-            name = "John",
-            surname = "Doe",
-            photo = "",
-            interests = listOf(Interest("Music", "Guitar"), Interest("Sport", "Running")),
-            activities = listOfActivitiesUid)
-
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PARTICIPANT_PROFILE)
     mockImageRepository = mock(ImageRepositoryFirestore::class.java)
     mockImageViewModel = ImageViewModel(mockImageRepository)
@@ -68,7 +72,8 @@ class ParticipantProfileScreenTest {
   fun displayLoadingScreenWhenNoParticipantSelected() {
     // Set up a null selected user to simulate loading
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
 
     composeTestRule.onNodeWithTag("loadingScreen").assertIsDisplayed()
@@ -82,22 +87,24 @@ class ParticipantProfileScreenTest {
     // Set up a null selected user to simulate loading
     listActivitiesViewModel.selectUser(testUser)
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
 
     composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("userName").assertTextEquals("John Doe")
+    composeTestRule.onNodeWithTag("userName").assertTextEquals("Amine A")
     composeTestRule.onNodeWithTag("interestsSection").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Guitar").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Running").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Cycling").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Reading").assertIsDisplayed()
   }
 
   @Test
   fun displayPastActivities() {
     listActivitiesViewModel.selectUser(testUser)
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
     composeTestRule
         .onNodeWithTag("ParticipantProfileContentColumn")
@@ -111,7 +118,8 @@ class ParticipantProfileScreenTest {
   fun displayParticipantActivitiesCreated() {
     listActivitiesViewModel.selectUser(testUser)
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
 
     composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
@@ -126,7 +134,8 @@ class ParticipantProfileScreenTest {
     listActivitiesViewModel.selectUser(testUser)
 
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
 
     composeTestRule.onNodeWithTag("ParticipantProfileContentColumn").assertIsDisplayed()
@@ -142,7 +151,8 @@ class ParticipantProfileScreenTest {
     listActivitiesViewModel.selectUser(testUser)
 
     composeTestRule.setContent {
-      ParticipantProfileScreen(listActivitiesViewModel, navigationActions, mockImageViewModel)
+      ParticipantProfileScreen(
+          listActivitiesViewModel, navigationActions, mockImageViewModel, userProfileViewModel)
     }
 
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -34,11 +34,10 @@ import org.mockito.kotlin.any
 class ProfileScreenTest {
 
   private lateinit var userProfileViewModel: ProfileViewModel
-  private lateinit var testUser: User
   private lateinit var navigationActions: NavigationActions
   private lateinit var listActivitiesViewModel: ListActivitiesViewModel
   private lateinit var activitiesRepository: ActivitiesRepository
-
+  private lateinit var testUser: User
   private lateinit var mockImageViewModel: ImageViewModel
   private lateinit var mockImageRepository: ImageRepositoryFirestore
 
@@ -46,16 +45,6 @@ class ProfileScreenTest {
 
   @Before
   fun setUp() {
-    activitiesRepository = mock(ActivitiesRepository::class.java)
-    userProfileViewModel = mock(ProfileViewModel::class.java)
-    listActivitiesViewModel =
-        ListActivitiesViewModel(mock(ProfilesRepository::class.java), activitiesRepository)
-
-    `when`(activitiesRepository.getActivities(any(), any())).then {
-      it.getArgument<(List<Activity>) -> Unit>(0)(activityListWithPastActivity)
-    }
-
-    listActivitiesViewModel.getActivities()
     testUser =
         User(
             id = "Rola",
@@ -66,6 +55,16 @@ class ProfileScreenTest {
                 listOf(Interest("Sport", "Cycling"), Interest("Indoor Activity", "Reading")),
             activities = listOfActivitiesUid,
         )
+    activitiesRepository = mock(ActivitiesRepository::class.java)
+    userProfileViewModel = mock(ProfileViewModel::class.java)
+    listActivitiesViewModel =
+        ListActivitiesViewModel(mock(ProfilesRepository::class.java), activitiesRepository)
+
+    `when`(activitiesRepository.getActivities(any(), any())).then {
+      it.getArgument<(List<Activity>) -> Unit>(0)(activityListWithPastActivity)
+    }
+
+    listActivitiesViewModel.getActivities()
     val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
@@ -116,7 +115,7 @@ class ProfileScreenTest {
   }
 
   @Test
-  fun goesToEditOnClick() {
+  fun goesToDetailsOnClick() {
     composeTestRule.setContent {
       ProfileScreen(
           userProfileViewModel = userProfileViewModel,
@@ -138,7 +137,7 @@ class ProfileScreenTest {
     composeTestRule.waitForIdle()
 
     // Verify that the navigation action was triggered
-    verify(navigationActions).navigateTo(Screen.EDIT_ACTIVITY)
+    verify(navigationActions).navigateTo(Screen.ACTIVITY_DETAILS)
   }
 
   @Test
@@ -160,7 +159,7 @@ class ProfileScreenTest {
   }
 
   @Test
-  fun navigateToPastActivityDetailsOrEdit() {
+  fun navigateToPastActivityDetails() {
     composeTestRule.setContent {
       ProfileScreen(
           userProfileViewModel = userProfileViewModel,
@@ -186,6 +185,6 @@ class ProfileScreenTest {
 
     // Verify navigation based on whether the user is the creator
     val pastActivity = activityListWithPastActivity.first { it.uid == listOfActivitiesUid.first() }
-    verify(navigationActions).navigateTo(Screen.EDIT_ACTIVITY)
+    verify(navigationActions).navigateTo(Screen.ACTIVITY_DETAILS)
   }
 }

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -133,7 +133,8 @@ fun NavGraph(
             imageViewModel)
       }
       composable(Screen.PARTICIPANT_PROFILE) {
-        ParticipantProfileScreen(listActivitiesViewModel, navigationActions, imageViewModel)
+        ParticipantProfileScreen(
+            listActivitiesViewModel, navigationActions, imageViewModel, profileViewModel)
       }
     }
 

--- a/app/src/main/java/com/android/sample/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/profile/ProfileViewModel.kt
@@ -1,9 +1,16 @@
 package com.android.sample.model.profile
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.database.AppDatabase
+import com.android.sample.model.network.NetworkManager
+import com.android.sample.ui.components.performOfflineAwareAction
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
 import com.google.firebase.Firebase
+import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -114,5 +121,22 @@ constructor(private val repository: ProfilesRepository, private val localDatabas
 
   fun loadCachedProfile(): User? {
     return runBlocking { localDatabase.userDao().getUser(Firebase.auth.currentUser?.uid ?: "") }
+  }
+  /** Check if the activity should be displayed based on the category and the user's role in the */
+  fun shouldShowActivity(activity: Activity, user: User, category: String): Boolean {
+    return when (category) {
+      "created" -> activity.creator == user.id && activity.date > Timestamp.now()
+      "enrolled" -> activity.creator != user.id && activity.date > Timestamp.now()
+      "past" -> activity.date < Timestamp.now()
+      else -> false
+    }
+  }
+  /** Navigate to the appropriate screen based on the category */
+  fun navigateToActivity(navigationActions: NavigationActions, context: Context) {
+    val networkManager = NetworkManager(context)
+    performOfflineAwareAction(
+        context,
+        networkManager,
+        onPerform = { navigationActions.navigateTo(Screen.ACTIVITY_DETAILS) })
   }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.image.ImageViewModel
+import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
@@ -36,7 +37,8 @@ import com.android.sample.ui.navigation.NavigationActions
 fun ParticipantProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel,
     navigationActions: NavigationActions,
-    imageViewModel: ImageViewModel
+    imageViewModel: ImageViewModel,
+    profileViewModel: ProfileViewModel
 ) {
 
   val selectedParticipant = listActivitiesViewModel.selectedUser.collectAsState().value
@@ -46,7 +48,11 @@ fun ParticipantProfileScreen(
         ParticipantLoadingScreen(navigationActions) // Show a loading indicator or a retry button
     else -> {
       ParticipantProfileContent(
-          user = profile, navigationActions, listActivitiesViewModel, imageViewModel)
+          user = profile,
+          navigationActions,
+          listActivitiesViewModel,
+          imageViewModel,
+          profileViewModel)
     }
   // Proceed with showing profile content
   }
@@ -87,7 +93,8 @@ fun ParticipantProfileContent(
     user: User,
     navigationActions: NavigationActions,
     listActivitiesViewModel: ListActivitiesViewModel,
-    imageViewModel: ImageViewModel
+    imageViewModel: ImageViewModel,
+    profileViewModel: ProfileViewModel
 ) {
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("profileScreen"),
@@ -127,15 +134,26 @@ fun ParticipantProfileContent(
 
               // Display activities sections
               this@LazyColumn.displayActivitySection(
-                  "Activities Created", "created", user, listActivitiesViewModel, navigationActions)
+                  "Activities Created",
+                  "created",
+                  user,
+                  listActivitiesViewModel,
+                  navigationActions,
+                  profileViewModel)
               this@LazyColumn.displayActivitySection(
                   "Activities Enrolled in",
                   "enrolled",
                   user,
                   listActivitiesViewModel,
-                  navigationActions)
+                  navigationActions,
+                  profileViewModel)
               this@LazyColumn.displayActivitySection(
-                  "Past Activities", "past", user, listActivitiesViewModel, navigationActions)
+                  "Past Activities",
+                  "past",
+                  user,
+                  listActivitiesViewModel,
+                  navigationActions,
+                  profileViewModel)
             }
       }
 }


### PR DESCRIPTION
This pull request includes several changes to the `ParticipantProfileScreenTest` and `ProfileScreenTests` as well as modifications to the `ProfileViewModel` and related UI components. The main focus is on integrating the `ProfileViewModel` into the `ParticipantProfileScreen` and updating the tests accordingly.

### Integration of `ProfileViewModel`:

* [`app/src/androidTest/java/com/android/sample/ui/profile/ParticipantProfileScreenTest.kt`](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cR17-R21): Added `ProfileViewModel` to the test setup and modified the `ParticipantProfileScreen` calls to include the new view model. Updated test user details and assertions to reflect the changes. [[1]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cR17-R21) [[2]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cR33-L34) [[3]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL43-R57) [[4]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL52-L61) [[5]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL71-R76) [[6]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL85-R107) [[7]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL114-R122) [[8]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL129-R138) [[9]](diffhunk://#diff-42dd8e7d296cb0bfedf30ecf38b6107f799b221a4be326348128ca91f7a53a3cL145-R155)
* [`app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt`](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L37-L58): Reordered and updated the initialization of `ProfileViewModel` and test user. Adjusted test methods to reflect the navigation changes. [[1]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L37-L58) [[2]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267R58-R67) [[3]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L119-R118) [[4]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L141-R140) [[5]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L163-R162) [[6]](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L189-R188)

### Updates to `ProfileViewModel`:

* [`app/src/main/java/com/android/sample/model/profile/ProfileViewModel.kt`](diffhunk://#diff-073810e870091592b72e4d424b52c902f41aba8566fea6027d676ed9bb99902cR3-R13): Added methods to check activity visibility based on the category and user's role, and to handle navigation to activity details. [[1]](diffhunk://#diff-073810e870091592b72e4d424b52c902f41aba8566fea6027d676ed9bb99902cR3-R13) [[2]](diffhunk://#diff-073810e870091592b72e4d424b52c902f41aba8566fea6027d676ed9bb99902cR125-R141)

### UI Component Adjustments:

* [`app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt`](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123R30): Updated `ParticipantProfileScreen` and `ParticipantProfileContent` to include `ProfileViewModel` and pass it to relevant sections. [[1]](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123R30) [[2]](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123L39-R41) [[3]](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123L49-R55) [[4]](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123L90-R97) [[5]](diffhunk://#diff-01ac6640618fe7bc453378d0d246643782bbc9958c236d1d06846699b55d5123L130-R156)
* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L3): Modified `ProfileContent` to include `ProfileViewModel` and adjust activity section display accordingly. [[1]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L3) [[2]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L51) [[3]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L185-R202)

### Navigation Changes:

* [`app/src/main/java/com/android/sample/MainActivity.kt`](diffhunk://#diff-0859fc4e472afc96e90cddd4bc16c22a149a751d8794a52a66c5053ec043660dL136-R137): Updated the navigation graph to include `ProfileViewModel` in the `ParticipantProfileScreen` composable.