### PR TITLE
Add caching for the profile in profile screen

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -57,26 +57,22 @@ fun ProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel,
     imageViewModel: ImageViewModel
 ) {
-    val context = LocalContext.current
-    val networkManager = NetworkManager(context)
+  val context = LocalContext.current
+  val networkManager = NetworkManager(context)
 
-    // Determine if we should use cached data
-    val profileState by userProfileViewModel.userState.collectAsState()
-    val user =
-        if (networkManager.isNetworkAvailable()) {
-            profileState
-        } else {
-            remember { mutableStateOf(userProfileViewModel.loadCachedProfile()) }.value
-        }
+  // Determine if we should use cached data
+  val profileState by userProfileViewModel.userState.collectAsState()
+  val user =
+      if (networkManager.isNetworkAvailable()) {
+        profileState
+      } else {
+        remember { mutableStateOf(userProfileViewModel.loadCachedProfile()) }.value
+      }
   when (user) {
     null -> LoadingScreen(navigationActions) // Show a loading indicator or a retry button
     else -> {
       ProfileContent(
-          user,
-          navigationActions,
-          listActivitiesViewModel,
-          userProfileViewModel,
-          imageViewModel)
+          user, navigationActions, listActivitiesViewModel, userProfileViewModel, imageViewModel)
     }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -57,12 +57,22 @@ fun ProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel,
     imageViewModel: ImageViewModel
 ) {
-  val profileState = userProfileViewModel.userState.collectAsState()
-  when (val profile = profileState.value) {
+    val context = LocalContext.current
+    val networkManager = NetworkManager(context)
+
+    // Determine if we should use cached data
+    val profileState by userProfileViewModel.userState.collectAsState()
+    val user =
+        if (networkManager.isNetworkAvailable()) {
+            profileState
+        } else {
+            remember { mutableStateOf(userProfileViewModel.loadCachedProfile()) }.value
+        }
+  when (user) {
     null -> LoadingScreen(navigationActions) // Show a loading indicator or a retry button
     else -> {
       ProfileContent(
-          user = profile,
+          user,
           navigationActions,
           listActivitiesViewModel,
           userProfileViewModel,

--- a/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
@@ -198,12 +198,11 @@ class ProfileViewModelTest {
 
   @Test
   fun fetchUserDataCachesLocallyOnSuccess() = runTest {
-    val mockUser = testUser // Replace with your test user object
 
     // Mock repository success behavior
-    `when`(profilesRepository.getUser(eq(mockUser.id), any(), any())).thenAnswer {
+    `when`(profilesRepository.getUser(eq(testUser.id), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(User?) -> Unit>(1)
-      onSuccess(mockUser)
+      onSuccess(testUser)
     }
 
     // Mock UserDao and AppDatabase
@@ -216,12 +215,12 @@ class ProfileViewModelTest {
         ProfileViewModel(repository = profilesRepository, localDatabase = mockDatabase)
 
     // Call the method under test
-    profileViewModel.fetchUserData(mockUser.id)
+    profileViewModel.fetchUserData(testUser.id)
 
     // Ensure the user state is updated
-    assertEquals(mockUser, profileViewModel.userState.value)
+    assertEquals(testUser, profileViewModel.userState.value)
 
     // Verify that the DAO's insert method was called
-    verify(mockUserDao).insert(mockUser)
+    verify(mockUserDao).insert(testUser)
   }
 }

--- a/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/model/profile/ProfileViewModelTest.kt
@@ -8,7 +8,6 @@ import com.android.sample.resources.dummydata.testUser
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -196,6 +195,7 @@ class ProfileViewModelTest {
     profileViewModel.clearUserData()
     assertEquals(null, profileViewModel.userState.value)
   }
+
   @Test
   fun fetchUserDataCachesLocallyOnSuccess() = runTest {
     val mockUser = testUser // Replace with your test user object
@@ -213,7 +213,7 @@ class ProfileViewModelTest {
 
     // Create the ViewModel
     val profileViewModel =
-      ProfileViewModel(repository = profilesRepository, localDatabase = mockDatabase)
+        ProfileViewModel(repository = profilesRepository, localDatabase = mockDatabase)
 
     // Call the method under test
     profileViewModel.fetchUserData(mockUser.id)


### PR DESCRIPTION
In this pull request, I added the same logic as in liked activities but to display the past activities, the enrolled activities and the created activities stored in the local database when the user is offline. 
### How to try the new feature:

1. Disable Wi-Fi and data
2. Open the App
3. Go to the profile screen
4. You should see all the activities in your profile screen even if you have no connection