### PR TITLE
Info pin  to explain what a PRO activity is 

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -2,7 +2,6 @@ package com.android.sample.ui.dialogs
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -128,36 +127,28 @@ class FilterDialogTest {
     assertEquals("2 hours", duration)
     assert(schedule != null) // Check timestamp is parsed
   }
+
   @Test
   fun test_PROInfo_initialState() {
 
-    composeTestRule.setContent {
-      PROinfo()
-    }
-
+    composeTestRule.setContent { PROinfo() }
 
     composeTestRule.onNodeWithTag("PROSection").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("infoIconButton").assertIsDisplayed()
 
-
     composeTestRule.onNodeWithTag("PROInfo").assertTextContains("PRO info")
-
 
     composeTestRule.onNodeWithTag("PROInfoDialog").assertDoesNotExist()
   }
+
   @Test
   fun test_PROInfo_dialogOpensOnClick() {
-    composeTestRule.setContent {
-      PROinfo()
-    }
-
+    composeTestRule.setContent { PROinfo() }
 
     composeTestRule.onNodeWithTag("infoIconButton").performClick()
 
-
     composeTestRule.onNodeWithTag("PROInfoDialog").assertIsDisplayed()
-
 
     composeTestRule.onNodeWithTag("PROInfoTitle").assertIsDisplayed()
     composeTestRule.onNodeWithTag("PROInfoText").assertIsDisplayed()
@@ -165,10 +156,7 @@ class FilterDialogTest {
 
   @Test
   fun test_PROInfo_dialogClosesOnOkClick() {
-    composeTestRule.setContent {
-      PROinfo()
-    }
-
+    composeTestRule.setContent { PROinfo() }
 
     composeTestRule.onNodeWithTag("infoIconButton").performClick()
 
@@ -176,8 +164,6 @@ class FilterDialogTest {
 
     composeTestRule.onNodeWithTag("okButton").performClick()
 
-
     composeTestRule.onNodeWithTag("PRODialog").assertDoesNotExist()
   }
-
 }

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -2,6 +2,7 @@ package com.android.sample.ui.dialogs
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -127,4 +128,56 @@ class FilterDialogTest {
     assertEquals("2 hours", duration)
     assert(schedule != null) // Check timestamp is parsed
   }
+  @Test
+  fun test_PROInfo_initialState() {
+
+    composeTestRule.setContent {
+      PROinfo()
+    }
+
+
+    composeTestRule.onNodeWithTag("PROSection").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("infoIconButton").assertIsDisplayed()
+
+
+    composeTestRule.onNodeWithTag("PROInfo").assertTextContains("PRO info")
+
+
+    composeTestRule.onNodeWithTag("PROInfoDialog").assertDoesNotExist()
+  }
+  @Test
+  fun test_PROInfo_dialogOpensOnClick() {
+    composeTestRule.setContent {
+      PROinfo()
+    }
+
+
+    composeTestRule.onNodeWithTag("infoIconButton").performClick()
+
+
+    composeTestRule.onNodeWithTag("PROInfoDialog").assertIsDisplayed()
+
+
+    composeTestRule.onNodeWithTag("PROInfoTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PROInfoText").assertIsDisplayed()
+  }
+
+  @Test
+  fun test_PROInfo_dialogClosesOnOkClick() {
+    composeTestRule.setContent {
+      PROinfo()
+    }
+
+
+    composeTestRule.onNodeWithTag("infoIconButton").performClick()
+
+    composeTestRule.onNodeWithTag("PROInfoDialog").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("okButton").performClick()
+
+
+    composeTestRule.onNodeWithTag("PRODialog").assertDoesNotExist()
+  }
+
 }

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -189,12 +189,12 @@ fun PROinfo() {
       androidx.compose.material3.Text(
           text = "PRO info",
           style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.padding(end = SMALL_PADDING.dp).testTag("paymentInfo"))
+          modifier = Modifier.padding(end = SMALL_PADDING.dp).testTag("PROInfo"))
       }
 
   if (showDialog) {
     androidx.compose.material3.AlertDialog(
-        modifier = Modifier.testTag("paymentInfoDialog"),
+        modifier = Modifier.testTag("PROInfoDialog"),
         onDismissRequest = { showDialog = false },
         confirmButton = {
           androidx.compose.material3.TextButton(

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -109,10 +110,10 @@ fun FilterDialog(
                     modifier = Modifier.testTag("durationTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
                 Spacer(modifier = Modifier.height(MEDIUM_PADDING.dp))
-                Row(modifier = Modifier.fillMaxWidth()) {
-                  Row(
-                      verticalAlignment = Alignment.CenterVertically,
-                      modifier = Modifier.testTag("onlyPROCheckboxRow")) {
+                Row(modifier = Modifier.fillMaxWidth().testTag("onlyPROCheckboxRow"),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+
                         Checkbox(
                             modifier = Modifier.testTag("onlyPROCheckbox"),
                             checked = onlyPRO ?: false,
@@ -124,8 +125,12 @@ fun FilterDialog(
                         Text(
                             "Only see PRO activities",
                         )
-                      }
+
+
                 }
+                Spacer(modifier = Modifier.height(SMALL_PADDING.dp))
+              PROinfo()
+
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
                   TextButton(
                       onClick = { onDismiss() }, modifier = Modifier.testTag("cancelButton")) {
@@ -163,4 +168,49 @@ fun FilterDialog(
               }
         }
       }
+}
+
+@Composable
+fun PROinfo() {
+  var showDialog by remember { mutableStateOf(false) }
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth().testTag("PROSection")) {
+
+
+
+        androidx.compose.material3.IconButton(
+            modifier = Modifier.testTag("infoIconButton"), onClick = { showDialog = true }) {
+              androidx.compose.material3.Icon(
+                  painter = painterResource(id = android.R.drawable.ic_dialog_info),
+                  contentDescription = "Info",
+                  tint = Color.Gray)
+            }
+      androidx.compose.material3.Text(
+          text = "PRO info",
+          style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.padding(end = SMALL_PADDING.dp).testTag("paymentInfo"))
+      }
+
+  if (showDialog) {
+    androidx.compose.material3.AlertDialog(
+        modifier = Modifier.testTag("paymentInfoDialog"),
+        onDismissRequest = { showDialog = false },
+        confirmButton = {
+          androidx.compose.material3.TextButton(
+              modifier = Modifier.testTag("okButton"), onClick = { showDialog = false }) {
+                androidx.compose.material3.Text(text = stringResource(id = R.string.ok))
+              }
+        },
+        title = {
+          androidx.compose.material3.Text(
+              modifier = Modifier.testTag("PROInfoTitle"),
+              text = stringResource(id = R.string.PRO_info))
+        },
+        text = {
+          androidx.compose.material3.Text(
+              modifier = Modifier.testTag("PROInfoText"),
+              text = stringResource(id = R.string.PRO_explanation))
+        })
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -110,26 +110,22 @@ fun FilterDialog(
                     modifier = Modifier.testTag("durationTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
                 Spacer(modifier = Modifier.height(MEDIUM_PADDING.dp))
-                Row(modifier = Modifier.fillMaxWidth().testTag("onlyPROCheckboxRow"),
+                Row(
+                    modifier = Modifier.fillMaxWidth().testTag("onlyPROCheckboxRow"),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-
-                        Checkbox(
-                            modifier = Modifier.testTag("onlyPROCheckbox"),
-                            checked = onlyPRO ?: false,
-                            onCheckedChange = { onlyPRO = it },
-                            colors =
-                                CheckboxDefaults.colors(
-                                    checkedColor = MaterialTheme.colors.primary),
-                        )
-                        Text(
-                            "Only see PRO activities",
-                        )
-
-
+                  Checkbox(
+                      modifier = Modifier.testTag("onlyPROCheckbox"),
+                      checked = onlyPRO ?: false,
+                      onCheckedChange = { onlyPRO = it },
+                      colors = CheckboxDefaults.colors(checkedColor = MaterialTheme.colors.primary),
+                  )
+                  Text(
+                      "Only see PRO activities",
+                  )
                 }
                 Spacer(modifier = Modifier.height(SMALL_PADDING.dp))
-              PROinfo()
+                PROinfo()
 
                 Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
                   TextButton(
@@ -176,9 +172,6 @@ fun PROinfo() {
   Row(
       verticalAlignment = Alignment.CenterVertically,
       modifier = Modifier.fillMaxWidth().testTag("PROSection")) {
-
-
-
         androidx.compose.material3.IconButton(
             modifier = Modifier.testTag("infoIconButton"), onClick = { showDialog = true }) {
               androidx.compose.material3.Icon(
@@ -186,10 +179,10 @@ fun PROinfo() {
                   contentDescription = "Info",
                   tint = Color.Gray)
             }
-      androidx.compose.material3.Text(
-          text = "PRO info",
-          style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.padding(end = SMALL_PADDING.dp).testTag("PROInfo"))
+        androidx.compose.material3.Text(
+            text = "PRO info",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(end = SMALL_PADDING.dp).testTag("PROInfo"))
       }
 
   if (showDialog) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,9 @@
     <string name="button_to_map">See on map</string>
     <string name="ok">OK</string>
     <string name="payment_info">Payment Information</string>
+    <string name="PRO_info">PRO Information</string>
     <string name="payment_explanation">The payment will be done on-site. Please ensure you have the necessary amount ready.</string>
+    <string name="PRO_explanation">A PRO activity is organized by an official institution that is susceptible to make profit from the activity.</string>
     <string name="free_activity">This activity is free. No payment is needed to attend.</string>
 
 


### PR DESCRIPTION

### **Feature: Add an Info Dialog to Explain "PRO" Activities**

#### **Summary**
This PR introduces an informational dialog that explains what a "PRO" activity is, to help users understand the meaning of such activities when browsing through the filter options.

---

#### **Details**

1. **Feature: Add Info Dialog for "PRO" Activities**
   - In the filter dialog, a new **info logo** is introduced.
   - When clicked, the info logo triggers a dialog that explains what a "PRO" activity is, providing users with clarity about the feature.

2. **Test: Verify the Behavior of the Info Pin**
   - Test cases have been added to ensure:
     - **Initial State**: The dialog remains hidden by default, and all key UI elements like the row, icon button, and explanatory text are displayed.
     - **Info Button Behavior**: The info button functions correctly, opening the dialog when clicked and displaying the correct title and explanation.
     - **"OK" Button**: The dialog can be closed by clicking the "OK" button, ensuring proper interaction.





Feel free to provide feedback or ask for any further adjustments!
closes #290

