### PR TITLE
refactor: change the currency to swiss francs in the filter dialog

### DIFF
--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -68,11 +68,11 @@ fun FilterDialog(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically) {
                       // Minimum Price Display
-                      Text(text = "€ 0,0", modifier = Modifier.testTag("minPriceDisplay"))
+                      Text(text = "CHF 0,0", modifier = Modifier.testTag("minPriceDisplay"))
 
                       // Maximum Price Display
                       Text(
-                          text = "€ ${"%.2f".format(maxPrice)}",
+                          text = "CHF ${"%.2f".format(maxPrice)}",
                           modifier = Modifier.testTag("maxPriceDisplay"))
                     }
                 Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION


### **Unify the Price Currency (CH) Everywhere in the App**  

#### **Summary**  
This is a very small PR that updates the currency displayed in the filter dialog to Swiss Francs (CHF), ensuring consistency in currency representation across the app.  

Let me know if you need further refinements or if there are other places in the app where the price is written in another currency !

Closes #300  



