### PR TITLE
Feature/images deleted activity

### DIFF
--- a/app/src/main/java/com/android/sample/model/activity/database/AppDatabase.kt
+++ b/app/src/main/java/com/android/sample/model/activity/database/AppDatabase.kt
@@ -7,7 +7,7 @@ import com.android.sample.model.activity.Activity
 import com.android.sample.model.profile.User
 import com.android.sample.model.profile.database.UserDao
 
-@Database(entities = [User::class, Activity::class], version = 1)
+@Database(entities = [User::class, Activity::class], version = 2)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
   abstract fun activityDao(): ActivityDao

--- a/app/src/main/java/com/android/sample/model/image/ImageRepository.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepository.kt
@@ -34,4 +34,10 @@ interface ImageRepository {
       onSuccess: (List<Bitmap>) -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun removeAllActivityImages(
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -152,7 +152,9 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
     activityFolderRef
         .listAll()
         .addOnSuccessListener { listResult ->
-                Log.d("ImageRepositoryFirestore", "Starting deletion of ${listResult.items.size} images for activity: activityId")
+          Log.d(
+              "ImageRepositoryFirestore",
+              "Starting deletion of ${listResult.items.size} images for activity: activityId")
 
           // Create deletion tasks for each file
           val deletionTasks = listResult.items.map { it.delete() }
@@ -169,7 +171,10 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
               }
         }
         .addOnFailureListener { exception ->
-        Log.e("ImageRepositoryFirestore", "Failed to delete images for activity: $activityId", exception)
+          Log.e(
+              "ImageRepositoryFirestore",
+              "Failed to delete images for activity: $activityId",
+              exception)
           // Handle failure to list files
           onFailure(exception)
         }

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -2,6 +2,7 @@ package com.android.sample.model.image
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Log
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -152,6 +152,8 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
     activityFolderRef
         .listAll()
         .addOnSuccessListener { listResult ->
+                Log.d("ImageRepositoryFirestore", "Starting deletion of ${listResult.items.size} images for activity: activityId")
+
           // Create deletion tasks for each file
           val deletionTasks = listResult.items.map { it.delete() }
 

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -169,6 +169,7 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
               }
         }
         .addOnFailureListener { exception ->
+        Log.e("ImageRepositoryFirestore", "Failed to delete images for activity: $activityId", exception)
           // Handle failure to list files
           onFailure(exception)
         }

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -140,4 +140,35 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
         },
         onFailure)
   }
+
+  override fun removeAllActivityImages(
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val activityFolderRef = storageRef.child("activities/$activityId")
+
+    // List all files in the activity's folder
+    activityFolderRef
+        .listAll()
+        .addOnSuccessListener { listResult ->
+          // Create deletion tasks for each file
+          val deletionTasks = listResult.items.map { it.delete() }
+
+          // Execute all deletion tasks
+          Tasks.whenAll(deletionTasks)
+              .addOnSuccessListener {
+                // Once all files are successfully deleted
+                onSuccess()
+              }
+              .addOnFailureListener { exception ->
+                // Handle any failure in the deletion process
+                onFailure(exception)
+              }
+        }
+        .addOnFailureListener { exception ->
+          // Handle failure to list files
+          onFailure(exception)
+        }
+  }
 }

--- a/app/src/main/java/com/android/sample/model/image/ImageViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageViewModel.kt
@@ -50,4 +50,12 @@ class ImageViewModel @Inject constructor(private val repository: ImageRepository
   ) {
     repository.fetchActivityImagesAsBitmaps(activityId, onSuccess, onFailure)
   }
+
+  fun removeAllActivityImages(
+      activityId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    repository.removeAllActivityImages(activityId, onSuccess, onFailure)
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -576,6 +576,13 @@ fun EditActivityScreen(
                     ),
                 onClick = {
                   listActivityViewModel.deleteActivityById(activity?.uid ?: "")
+                  imageViewModel.removeAllActivityImages(
+                      activity?.uid ?: "",
+                      { Log.d("EditActivityScreen", "Images removed") },
+                      { error ->
+                        Log.e("EditActivityScreen", "Failed to remove images: ${error.message}")
+                      })
+
                   navigationActions.navigateTo(Screen.OVERVIEW)
                 },
                 modifier =


### PR DESCRIPTION
This pull request introduces functionality to ensure that all associated images in Firebase Storage are deleted when an activity is deleted. This update helps in managing storage by preventing orphaned images that consume space unnecessarily.

Main Changes:
Remove Activity Images: Implemented a new function removeAllActivityImages which deletes all images from the Firebase Storage path corresponding to an activity when it is deleted.
Database Version Update: Incremented the Room database version by 1 to reflect changes in the schema or data handling related to activity deletions.