### PR TITLE
remove go back button in profile and center title in ProfileScreen.kt

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -112,11 +112,7 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("Cycling").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Reading").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("goBackButton")
-        .performClick() // test for if on click it goes back
   }
 
   @Test

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -133,7 +133,11 @@ fun ProfileContent(
       },
       topBar = {
         TopAppBar(
-            title = { Text("Profile") },
+            title = {
+              Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Profile")
+              }
+            },
             actions = {
               IconButton(
                   onClick = { showMenu = true }, modifier = Modifier.testTag("moreOptionsButton")) {

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.ThumbDown
@@ -135,15 +134,6 @@ fun ProfileContent(
       topBar = {
         TopAppBar(
             title = { Text("Profile") },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("goBackButton")) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                        contentDescription = "Back")
-                  }
-            },
             actions = {
               IconButton(
                   onClick = { showMenu = true }, modifier = Modifier.testTag("moreOptionsButton")) {


### PR DESCRIPTION
This pull request focuses on removing the "go back" button functionality from the profile screen and its associated tests. The changes include removing the button from the UI and the corresponding test cases.

Changes to profile screen UI:

* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L15): Removed the "go back" button from the `TopAppBar` and its associated import statement. [[1]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L15) [[2]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L137-R138)

Changes to profile screen tests:

* [`app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt`](diffhunk://#diff-0dc8d4adae9e126d19faaeea370846ec4452fcf8524813e14c9bbda7f344d267L115-L119): Removed the test cases related to the "go back" button.