### PR TITLE
refactor : replace floatingActionButton the navigates to EditProfileScreen by a DropDownMenu

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material.icons.filled.ThumbUp
@@ -165,13 +164,11 @@ fun ProfileContent(
                           })
                     },
                     enabled = Firebase.auth.currentUser?.isAnonymous == false)
+                DropdownMenuItem(
+                    text = { Text("Edit profile") },
+                    onClick = { navigationActions.navigateTo(Screen.EDIT_PROFILE) })
               }
             })
-      },
-      floatingActionButton = {
-        FloatingActionButton(onClick = { navigationActions.navigateTo(Screen.EDIT_PROFILE) }) {
-          Icon(Icons.Filled.ModeEdit, contentDescription = "Edit Profile")
-        }
       }) { innerPadding ->
         LazyColumn(
             Modifier.fillMaxSize().padding(innerPadding).testTag("profileContentColumn"),


### PR DESCRIPTION
This pull request includes changes to the `Profile.kt` file to improve the user interface and navigation experience in the profile section of the application. The most important changes include removing the floating action button for editing the profile and adding an option to the dropdown menu for the same action.

Improvements to user interface and navigation:

* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266R167-L174): Removed the floating action button for editing the profile.
* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266R167-L174): Added an "Edit profile" option to the dropdown menu.

Code cleanup:

* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L16): Removed unused import for `ModeEdit` icon.