### PR TITLE
fix : remove useless blank space in the Map screen

### DIFF
--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -135,11 +135,41 @@ fun MapScreen(
   }
 
   Scaffold(
+      floatingActionButton = {
+          Row(
+              modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = MEDIUM_PADDING.dp),
+              horizontalArrangement = Arrangement.SpaceBetween
+          ){
+          FloatingActionButton(
+              modifier =
+              Modifier.padding(horizontal = MEDIUM_PADDING.dp).testTag("centerOnCurrentLocation"),
+              onClick = {
+                  coroutineScope.launch {
+                      currentLocation?.let {
+                          val locationLatLng = LatLng(it.latitude, it.longitude)
+                          cameraPositionState.animate(
+                              update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
+                              durationMs = 800)
+                      }
+                  }
+              }) {
+              Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
+          }
+          FloatingActionButton(
+              modifier =
+              Modifier.padding(horizontal = MEDIUM_PADDING.dp).testTag("filterDialogButton"),
+              onClick = { showFilterDialog = true }) {
+              Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
+          }
+              }
+      },
       content = { padding ->
         if (!networkManager.isNetworkAvailable()) {
           NoInternetScreen(padding)
         } else {
-          Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+          Box(modifier = Modifier.fillMaxSize()) {
             GoogleMap(
                 modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
                 cameraPositionState = cameraPositionState) {
@@ -187,32 +217,6 @@ fun MapScreen(
                                 BitmapFactory.decodeResource(
                                     context.resources, R.drawable.current_location)))
                   }
-                }
-
-            FloatingActionButton(
-                modifier =
-                    Modifier.align(Alignment.BottomStart)
-                        .padding(MEDIUM_PADDING.dp)
-                        .testTag("centerOnCurrentLocation"),
-                onClick = {
-                  coroutineScope.launch {
-                    currentLocation?.let {
-                      val locationLatLng = LatLng(it.latitude, it.longitude)
-                      cameraPositionState.animate(
-                          update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
-                          durationMs = 800)
-                    }
-                  }
-                }) {
-                  Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
-                }
-            FloatingActionButton(
-                modifier =
-                    Modifier.align(Alignment.BottomEnd)
-                        .padding(MEDIUM_PADDING.dp)
-                        .testTag("filterDialogButton"),
-                onClick = { showFilterDialog = true }) {
-                  Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
                 }
           }
         }

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -136,34 +136,34 @@ fun MapScreen(
 
   Scaffold(
       floatingActionButton = {
-          Row(
-              modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(horizontal = MEDIUM_PADDING.dp),
-              horizontalArrangement = Arrangement.SpaceBetween
-          ){
-          FloatingActionButton(
-              modifier =
-              Modifier.padding(horizontal = MEDIUM_PADDING.dp).testTag("centerOnCurrentLocation"),
-              onClick = {
-                  coroutineScope.launch {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = MEDIUM_PADDING.dp),
+            horizontalArrangement = Arrangement.SpaceBetween) {
+              FloatingActionButton(
+                  modifier =
+                      Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+                          .testTag("centerOnCurrentLocation"),
+                  onClick = {
+                    coroutineScope.launch {
                       currentLocation?.let {
-                          val locationLatLng = LatLng(it.latitude, it.longitude)
-                          cameraPositionState.animate(
-                              update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
-                              durationMs = 800)
+                        val locationLatLng = LatLng(it.latitude, it.longitude)
+                        cameraPositionState.animate(
+                            update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
+                            durationMs = 800)
                       }
+                    }
+                  }) {
+                    Icon(
+                        Icons.Default.MyLocation, contentDescription = "Center on current location")
                   }
-              }) {
-              Icon(Icons.Default.MyLocation, contentDescription = "Center on current location")
-          }
-          FloatingActionButton(
-              modifier =
-              Modifier.padding(horizontal = MEDIUM_PADDING.dp).testTag("filterDialogButton"),
-              onClick = { showFilterDialog = true }) {
-              Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
-          }
-              }
+              FloatingActionButton(
+                  modifier =
+                      Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+                          .testTag("filterDialogButton"),
+                  onClick = { showFilterDialog = true }) {
+                    Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
+                  }
+            }
       },
       content = { padding ->
         if (!networkManager.isNetworkAvailable()) {


### PR DESCRIPTION
This pull request includes changes to the `MapScreen` function in the `Map.kt` file to improve the layout of the floating action buttons. The most important changes involve moving the floating action buttons into a row within the `Scaffold`'s `floatingActionButton` parameter, allowing for better arrangement and spacing.

Improvements to floating action buttons layout:

* [`app/src/main/java/com/android/sample/ui/map/Map.kt`](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R138-R172): Added a `Row` to the `Scaffold`'s `floatingActionButton` parameter to contain the floating action buttons, ensuring they are properly spaced and aligned horizontally.
* [`app/src/main/java/com/android/sample/ui/map/Map.kt`](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8L191-L216): Removed the previous individual floating action buttons that were aligned to the bottom start and bottom end of the screen.