### PR TITLE
Feature/already enrolled remaining time

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -26,6 +26,7 @@ import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import java.lang.Thread.sleep
 import java.sql.Timestamp
+import java.util.Calendar
 import java.util.Date
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
@@ -35,7 +36,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
-import java.util.Calendar
 
 class ProfileScreenTest {
 
@@ -196,20 +196,23 @@ class ProfileScreenTest {
 
   @Test
   fun test_RemainingTime_ForMonths() {
-      val futureDate = com.google.firebase.Timestamp(Date(System.currentTimeMillis() + 305L * 30 * 24 * 60 * 60 * 1000)) // 305 months from now
-      val activity = activity1.copy(date = futureDate, startTime = "12:00") // Start time is noon
+    val futureDate =
+        com.google.firebase.Timestamp(
+            Date(
+                System.currentTimeMillis() +
+                    305L * 30 * 24 * 60 * 60 * 1000)) // 305 months from now
+    val activity = activity1.copy(date = futureDate, startTime = "12:00") // Start time is noon
 
-      composeTestRule.setContent { RemainingTime(activity = activity) }
-      sleep(5000)
-      composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
-      composeTestRule.onNodeWithText("In 304 months").assertIsDisplayed()
+    composeTestRule.setContent { RemainingTime(activity = activity) }
+    sleep(5000)
+    composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
+    composeTestRule.onNodeWithText("In 304 months").assertIsDisplayed()
   }
 
   @Test
   fun test_RemainingTime_ForDays() {
     val futureDate =
-        com.google.firebase.Timestamp(
-            Date(System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000))
+        com.google.firebase.Timestamp(Date(System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000))
     val activity = activity1.copy(date = futureDate)
 
     composeTestRule.setContent { RemainingTime(activity = activity) }
@@ -219,18 +222,18 @@ class ProfileScreenTest {
 
   @Test
   fun test_RemainingTime_ForHours() {
-      val currentTime = System.currentTimeMillis()
-      val futureDate = com.google.firebase.Timestamp(Date(currentTime))
-      val calendar = Calendar.getInstance().apply { timeInMillis = currentTime }
-      calendar.add(Calendar.MINUTE, 30)
-      val futureStartTime = "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}"
+    val currentTime = System.currentTimeMillis()
+    val futureDate = com.google.firebase.Timestamp(Date(currentTime))
+    val calendar = Calendar.getInstance().apply { timeInMillis = currentTime }
+    calendar.add(Calendar.MINUTE, 30)
+    val futureStartTime = "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}"
 
-      val activity = activity1.copy(date = futureDate, startTime = futureStartTime)
+    val activity = activity1.copy(date = futureDate, startTime = futureStartTime)
 
-      composeTestRule.setContent { RemainingTime(activity = activity) }
-      sleep(5000)
-      composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
-      composeTestRule.onNodeWithText("In 0 h 29 min").assertIsDisplayed()
+    composeTestRule.setContent { RemainingTime(activity = activity) }
+    sleep(5000)
+    composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
+    composeTestRule.onNodeWithText("In 0 h 29 min").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -35,6 +35,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import java.util.Calendar
 
 class ProfileScreenTest {
 
@@ -195,17 +196,20 @@ class ProfileScreenTest {
 
   @Test
   fun test_RemainingTime_ForMonths() {
-    composeTestRule.setContent { RemainingTime(activity = activity1) }
-    sleep(5000)
-    composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
-    composeTestRule.onNodeWithText("In 305 months").assertIsDisplayed()
+      val futureDate = com.google.firebase.Timestamp(Date(System.currentTimeMillis() + 305L * 30 * 24 * 60 * 60 * 1000)) // 305 months from now
+      val activity = activity1.copy(date = futureDate, startTime = "12:00") // Start time is noon
+
+      composeTestRule.setContent { RemainingTime(activity = activity) }
+      sleep(5000)
+      composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
+      composeTestRule.onNodeWithText("In 304 months").assertIsDisplayed()
   }
 
   @Test
   fun test_RemainingTime_ForDays() {
     val futureDate =
         com.google.firebase.Timestamp(
-            Date(System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000)) // 7 days from now
+            Date(System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000))
     val activity = activity1.copy(date = futureDate)
 
     composeTestRule.setContent { RemainingTime(activity = activity) }
@@ -215,14 +219,18 @@ class ProfileScreenTest {
 
   @Test
   fun test_RemainingTime_ForHours() {
-    val futureDate =
-        com.google.firebase.Timestamp(
-            Date(System.currentTimeMillis() + 2L * 60 * 60 * 1000)) // 2 hours from now
-    val activity = activity1.copy(date = futureDate)
+      val currentTime = System.currentTimeMillis()
+      val futureDate = com.google.firebase.Timestamp(Date(currentTime))
+      val calendar = Calendar.getInstance().apply { timeInMillis = currentTime }
+      calendar.add(Calendar.MINUTE, 30)
+      val futureStartTime = "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}"
 
-    composeTestRule.setContent { RemainingTime(activity = activity) }
+      val activity = activity1.copy(date = futureDate, startTime = futureStartTime)
 
-    composeTestRule.onNodeWithText("In 1 h 59 min").assertIsDisplayed()
+      composeTestRule.setContent { RemainingTime(activity = activity) }
+      sleep(5000)
+      composeTestRule.onNodeWithTag("remainingTime").assertIsDisplayed()
+      composeTestRule.onNodeWithText("In 0 h 29 min").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -57,6 +57,7 @@ import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import java.util.Calendar
 
 @Composable
 fun ProfileScreen(
@@ -355,9 +356,24 @@ fun ActivityRow(
 
 @Composable
 fun RemainingTime(activity: Activity) {
-  val currentTimeMillis = System.currentTimeMillis()
-  val activityTimeMillis = activity.date.toDate().time
-  val remainingTimeMillis = activityTimeMillis - currentTimeMillis
+    val currentTimeMillis = System.currentTimeMillis()
+
+    val startTimeParts = activity.startTime.split(":")
+    val activityHour = startTimeParts[0].toInt()
+    val activityMinute = startTimeParts[1].toInt()
+
+
+    val activityDate = activity.date.toDate()
+    val calendar = Calendar.getInstance().apply {
+        time = activityDate
+        set(Calendar.HOUR_OF_DAY, activityHour)
+        set(Calendar.MINUTE, activityMinute)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+    val activityTimeMillis = calendar.timeInMillis
+
+    val remainingTimeMillis = activityTimeMillis - currentTimeMillis
 
   val hours = remainingTimeMillis / (1000 * 60 * 60) % 24
   val minutes = remainingTimeMillis / (1000 * 60) % 60

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -356,24 +356,24 @@ fun ActivityRow(
 
 @Composable
 fun RemainingTime(activity: Activity) {
-    val currentTimeMillis = System.currentTimeMillis()
+  val currentTimeMillis = System.currentTimeMillis()
 
-    val startTimeParts = activity.startTime.split(":")
-    val activityHour = startTimeParts[0].toInt()
-    val activityMinute = startTimeParts[1].toInt()
+  val startTimeParts = activity.startTime.split(":")
+  val activityHour = startTimeParts[0].toInt()
+  val activityMinute = startTimeParts[1].toInt()
 
-
-    val activityDate = activity.date.toDate()
-    val calendar = Calendar.getInstance().apply {
+  val activityDate = activity.date.toDate()
+  val calendar =
+      Calendar.getInstance().apply {
         time = activityDate
         set(Calendar.HOUR_OF_DAY, activityHour)
         set(Calendar.MINUTE, activityMinute)
         set(Calendar.SECOND, 0)
         set(Calendar.MILLISECOND, 0)
-    }
-    val activityTimeMillis = calendar.timeInMillis
+      }
+  val activityTimeMillis = calendar.timeInMillis
 
-    val remainingTimeMillis = activityTimeMillis - currentTimeMillis
+  val remainingTimeMillis = activityTimeMillis - currentTimeMillis
 
   val hours = remainingTimeMillis / (1000 * 60 * 60) % 24
   val minutes = remainingTimeMillis / (1000 * 60) % 60


### PR DESCRIPTION
### **Fix: Correct Remaining Time Calculation for Activities**

#### **Summary**
This PR addresses a bug introduced in a previously merged PR (#298) that caused the displayed remaining hours and minutes for activities to be calculated incorrectly. The issue stemmed from only considering the activity's date, ignoring its start time. This PR resolves the bug and ensures the remaining time is accurately displayed. Additionally, it updates the existing tests to reflect the fixed logic.

---

#### **Problem**
In the previous implementation:
- The **remaining time** calculation only used the activity's date.
- The **start time** of the activity was omitted, leading to incorrect remaining hours and minutes being displayed.

---

#### **Fix**
1. **Corrected Remaining Time Calculation Logic**:
   - Updated the logic to incorporate both the **date** and **start time** of the activity.
   - The calculation now provides an accurate representation of the remaining time, down to hours and minutes.

2. **Updated Tests**:
   - Modified existing tests to account for the corrected logic.
   - Ensured that scenarios involving both date and time are properly validated.

---


#### **Linked Issues**
- Resolves bug from PR #298.

---

Let me know if further details are needed!