### PR TITLE
feat: Add distance-based filtering, a time slot filtering and a Deadline filtering for activities on the map screen and on the overview

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -132,7 +132,7 @@ class FilterDialogTest {
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput("5")
     composeTestRule.onNodeWithTag("minDateTextField").performTextInput("15/09/2024")
     composeTestRule.onNodeWithTag("durationTextField").performTextInput("2 hours")
-    composeTestRule.onNodeWithTag("distanceTextField").performTextInput("10 km")
+    composeTestRule.onNodeWithTag("distanceTextField").performTextInput("10")
     composeTestRule.onNodeWithText("Filter").performClick()
 
     // Verify filter callback

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import com.google.firebase.Timestamp
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -18,13 +17,17 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldDisplayAllComponents() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
 
     composeTestRule.onNodeWithTag("FilterDialog").assertIsDisplayed()
     composeTestRule.onNodeWithText("Price Range").assertIsDisplayed()
     composeTestRule.onNodeWithTag("membersAvailableTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("minDateTextField").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("maxDateTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("startTimeTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("endTimeTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("distanceTextField").assertIsDisplayed()
     composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
     composeTestRule.onNodeWithText("Filter").assertIsDisplayed()
@@ -49,7 +52,9 @@ class FilterDialogTest {
   */
   @Test
   fun filterDialog_shouldUpdateMembersAvailable() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
 
     val inputText = "10"
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput(inputText)
@@ -60,7 +65,9 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldSetStartDate() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
 
     val startDate = "15/09/2024"
     composeTestRule.onNodeWithTag("minDateTextField").performTextInput(startDate)
@@ -70,19 +77,49 @@ class FilterDialogTest {
   }
 
   @Test
-  fun filterDialog_shouldSetDuration() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+  fun filterDialog_shouldSetEndDate() {
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
 
-    val duration = "2 hours"
-    composeTestRule.onNodeWithTag("durationTextField").performTextInput(duration)
+    val startDate = "17/09/2024"
+    composeTestRule.onNodeWithTag("maxDateTextField").performTextInput(startDate)
 
     // Verify the input value
-    composeTestRule.onNodeWithTag("durationTextField").assertTextContains(duration)
+    composeTestRule.onNodeWithTag("maxDateTextField").assertTextContains(startDate)
+  }
+
+  @Test
+  fun filterDialog_shouldSetStartTime() {
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
+
+    val startTime = "00:45"
+    composeTestRule.onNodeWithTag("startTimeTextField").performTextInput(startTime)
+
+    // Verify the input value
+    composeTestRule.onNodeWithTag("startTimeTextField").assertTextContains(startTime)
+  }
+
+  @Test
+  fun filterDialog_shouldSetEndTime() {
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
+
+    val endTime = "01:45"
+    composeTestRule.onNodeWithTag("endTimeTextField").performTextInput(endTime)
+
+    // Verify the input value
+    composeTestRule.onNodeWithTag("endTimeTextField").assertTextContains(endTime)
   }
 
   @Test
   fun filterDialog_shouldSetDistance() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+    composeTestRule.setContent {
+      FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _, _, _ -> })
+    }
 
     val distance = "10"
     composeTestRule.onNodeWithTag("distanceTextField").performTextInput(distance)
@@ -96,7 +133,7 @@ class FilterDialogTest {
     var dismissed = false
 
     composeTestRule.setContent {
-      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _, _, _ -> })
+      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _, _, _, _, _ -> })
     }
 
     // Perform click on Cancel
@@ -111,27 +148,27 @@ class FilterDialogTest {
     var filterCalled = false
     var maxPrice: Double? = null
     var membersAvailable: Int? = null
-    var schedule: Timestamp? = null
-    var duration: String? = null
+    var startTime: String? = null
+    var endTime: String? = null
     var distance: Double? = null
 
     composeTestRule.setContent {
       FilterDialog(
           onDismiss = {},
-          onFilter = { price, members, date, dur, dist, _ ->
+          onFilter = { price, members, _, _, startT, endT, dist, _ ->
             filterCalled = true
             maxPrice = price
             membersAvailable = members
-            schedule = date
-            duration = dur
+            startTime = startT
+            endTime = endT
             distance = dist
           })
     }
 
     // Set values
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput("5")
-    composeTestRule.onNodeWithTag("minDateTextField").performTextInput("15/09/2024")
-    composeTestRule.onNodeWithTag("durationTextField").performTextInput("2 hours")
+    composeTestRule.onNodeWithTag("startTimeTextField").performTextInput("17:00")
+    composeTestRule.onNodeWithTag("endTimeTextField").performTextInput("19:00")
     composeTestRule.onNodeWithTag("distanceTextField").performTextInput("10")
     composeTestRule.onNodeWithText("Filter").performClick()
 
@@ -139,9 +176,9 @@ class FilterDialogTest {
     assert(filterCalled)
     assertEquals(300.0, maxPrice) // Default max price
     assertEquals(5, membersAvailable)
-    assertEquals("2 hours", duration)
+    assertEquals("17:00", startTime)
+    assertEquals("19:00", endTime)
     assertEquals(10.0, distance)
-    assert(schedule != null) // Check timestamp is parsed
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -18,13 +18,14 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldDisplayAllComponents() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _,_ -> }) }
 
     composeTestRule.onNodeWithTag("FilterDialog").assertIsDisplayed()
     composeTestRule.onNodeWithText("Price Range").assertIsDisplayed()
     composeTestRule.onNodeWithTag("membersAvailableTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("minDateTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("distanceTextField").assertIsDisplayed()
     composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
     composeTestRule.onNodeWithText("Filter").assertIsDisplayed()
   }
@@ -48,7 +49,7 @@ class FilterDialogTest {
   */
   @Test
   fun filterDialog_shouldUpdateMembersAvailable() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _,_ ,_ -> }) }
 
     val inputText = "10"
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput(inputText)
@@ -59,7 +60,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldSetStartDate() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
 
     val startDate = "15/09/2024"
     composeTestRule.onNodeWithTag("minDateTextField").performTextInput(startDate)
@@ -70,7 +71,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldSetDuration() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
 
     val duration = "2 hours"
     composeTestRule.onNodeWithTag("durationTextField").performTextInput(duration)
@@ -78,13 +79,23 @@ class FilterDialogTest {
     // Verify the input value
     composeTestRule.onNodeWithTag("durationTextField").assertTextContains(duration)
   }
+  @Test
+  fun filterDialog_shouldSetDistance() {
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
+
+    val distance = "10"
+    composeTestRule.onNodeWithTag("distanceTextField").performTextInput(distance)
+
+    // Verify the input value
+    composeTestRule.onNodeWithTag("distanceTextField").assertTextContains(distance)
+  }
 
   @Test
   fun filterDialog_shouldDismissOnCancel() {
     var dismissed = false
 
     composeTestRule.setContent {
-      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _, _ -> })
+      FilterDialog(onDismiss = { dismissed = true }, onFilter = { _, _, _, _, _, _ -> })
     }
 
     // Perform click on Cancel
@@ -101,16 +112,18 @@ class FilterDialogTest {
     var membersAvailable: Int? = null
     var schedule: Timestamp? = null
     var duration: String? = null
+    var distance: Double? = null
 
     composeTestRule.setContent {
       FilterDialog(
           onDismiss = {},
-          onFilter = { price, members, date, dur, _ ->
+          onFilter = { price, members, date, dur, dist, _ ->
             filterCalled = true
             maxPrice = price
             membersAvailable = members
             schedule = date
             duration = dur
+            distance = dist
           })
     }
 
@@ -118,6 +131,7 @@ class FilterDialogTest {
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput("5")
     composeTestRule.onNodeWithTag("minDateTextField").performTextInput("15/09/2024")
     composeTestRule.onNodeWithTag("durationTextField").performTextInput("2 hours")
+    composeTestRule.onNodeWithTag("distanceTextField").performTextInput("10 km")
     composeTestRule.onNodeWithText("Filter").performClick()
 
     // Verify filter callback
@@ -125,6 +139,7 @@ class FilterDialogTest {
     assertEquals(300.0, maxPrice) // Default max price
     assertEquals(5, membersAvailable)
     assertEquals("2 hours", duration)
+    assertEquals(10.0, distance)
     assert(schedule != null) // Check timestamp is parsed
   }
 

--- a/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/dialogs/FilterDialogTest.kt
@@ -18,7 +18,7 @@ class FilterDialogTest {
 
   @Test
   fun filterDialog_shouldDisplayAllComponents() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _,_ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
 
     composeTestRule.onNodeWithTag("FilterDialog").assertIsDisplayed()
     composeTestRule.onNodeWithText("Price Range").assertIsDisplayed()
@@ -49,7 +49,7 @@ class FilterDialogTest {
   */
   @Test
   fun filterDialog_shouldUpdateMembersAvailable() {
-    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _,_ ,_ -> }) }
+    composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }
 
     val inputText = "10"
     composeTestRule.onNodeWithTag("membersAvailableTextField").performTextInput(inputText)
@@ -79,6 +79,7 @@ class FilterDialogTest {
     // Verify the input value
     composeTestRule.onNodeWithTag("durationTextField").assertTextContains(duration)
   }
+
   @Test
   fun filterDialog_shouldSetDistance() {
     composeTestRule.setContent { FilterDialog(onDismiss = {}, onFilter = { _, _, _, _, _, _ -> }) }

--- a/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
@@ -39,6 +39,7 @@ constructor(
   var availablePlaces by mutableStateOf<Int?>(null)
   var minDate by mutableStateOf<Timestamp?>(null)
   var duration by mutableStateOf<String?>(null)
+  var distance by mutableStateOf<Double?>(null)
   var onlyPRO by mutableStateOf(false)
 
   /** Set the UI state to a new value For testing purposes only */
@@ -59,12 +60,14 @@ constructor(
       placesAvailable: Int?,
       mindateTimestamp: Timestamp?,
       acDuration: String?,
+      distance: Double?,
       seeOnlyPRO: Boolean?
   ) {
     maxPrice = price ?: Double.MAX_VALUE
     availablePlaces = placesAvailable
     minDate = mindateTimestamp
     duration = acDuration
+    this.distance = distance
     onlyPRO = seeOnlyPRO ?: false
   }
 

--- a/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
@@ -38,7 +38,10 @@ constructor(
   var maxPrice by mutableStateOf(Double.MAX_VALUE)
   var availablePlaces by mutableStateOf<Int?>(null)
   var minDate by mutableStateOf<Timestamp?>(null)
-  var duration by mutableStateOf<String?>(null)
+  var maxDate by mutableStateOf<Timestamp?>(null)
+
+  var startTime by mutableStateOf<String?>(null)
+  var endTime by mutableStateOf<String?>(null)
   var distance by mutableStateOf<Double?>(null)
   var onlyPRO by mutableStateOf(false)
 
@@ -58,15 +61,19 @@ constructor(
   fun updateFilterState(
       price: Double?,
       placesAvailable: Int?,
-      mindateTimestamp: Timestamp?,
-      acDuration: String?,
+      minDateTimestamp: Timestamp?,
+      maxDateTimestamp: Timestamp?,
+      startTime: String?,
+      endTime: String?,
       distance: Double?,
       seeOnlyPRO: Boolean?
   ) {
     maxPrice = price ?: Double.MAX_VALUE
     availablePlaces = placesAvailable
-    minDate = mindateTimestamp
-    duration = acDuration
+    minDate = minDateTimestamp
+    maxDate = maxDateTimestamp
+    this.startTime = startTime
+    this.endTime = endTime
     this.distance = distance
     onlyPRO = seeOnlyPRO ?: false
   }

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -20,6 +20,8 @@ object C {
 
     const val STANDARD_PADDING = 8
 
+    const val HALF_SCREEN_TEXT_FIELD_PADDING = 120
+
     const val DEFAULT_MAX_PRICE = 300f
 
     const val BUTTON_WIDTH = 300

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -34,6 +34,7 @@ fun FilterDialog(
             membersAvailable: Int?,
             schedule: Timestamp?,
             duration: String?,
+            distance: Double?,
             onlyPRO: Boolean?) -> Unit,
 ) {
   var maxPrice by remember { mutableStateOf(DEFAULT_MAX_PRICE) }
@@ -42,6 +43,7 @@ fun FilterDialog(
   var minDateTimestamp by remember { mutableStateOf<Timestamp?>(null) }
   var duration by remember { mutableStateOf<String?>(null) }
   var onlyPRO by remember { mutableStateOf<Boolean?>(false) }
+  var distance by remember { mutableStateOf<String?>(null) }
 
   Dialog(
       onDismissRequest = { onDismiss() },
@@ -89,6 +91,7 @@ fun FilterDialog(
                     value = availablePlaces?.toString() ?: "",
                     onValueChange = { availablePlaces = it.toIntOrNull() },
                     label = { Text("Members Available") },
+                    singleLine = true,
                     modifier = Modifier.testTag("membersAvailableTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
 
@@ -107,7 +110,16 @@ fun FilterDialog(
                     value = duration ?: "",
                     onValueChange = { duration = it },
                     label = { Text("Duration") },
+                    singleLine = true,
                     modifier = Modifier.testTag("durationTextField"),
+                    shape = RoundedCornerShape(TEXT_PADDING.dp))
+                OutlinedTextField(
+                    value = distance ?: "",
+                    onValueChange = { distance = it },
+                    label = { Text("distance") },
+                    modifier = Modifier.testTag("distanceTextField"),
+                    placeholder = { androidx.compose.material3.Text(text = "exp: 10.5 km") },
+                    singleLine = true,
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
                 Spacer(modifier = Modifier.height(MEDIUM_PADDING.dp))
                 Row(
@@ -154,6 +166,7 @@ fun FilterDialog(
                             availablePlaces,
                             minDateTimestamp,
                             duration,
+                            distance?.toDouble(),
                             onlyPRO)
                         onDismiss()
                       },

--- a/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/dialogs/FilterDialog.kt
@@ -2,8 +2,11 @@ package com.android.sample.ui.dialogs
 
 import android.icu.util.GregorianCalendar
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -18,6 +21,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.android.sample.R
 import com.android.sample.resources.C.Tag.DEFAULT_MAX_PRICE
 import com.android.sample.resources.C.Tag.DIALOG_PADDING
+import com.android.sample.resources.C.Tag.HALF_SCREEN_TEXT_FIELD_PADDING
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
@@ -32,16 +36,21 @@ fun FilterDialog(
         (
             price: Double?,
             membersAvailable: Int?,
-            schedule: Timestamp?,
-            duration: String?,
+            minDate: Timestamp?,
+            maxDate: Timestamp?,
+            startTime: String?,
+            endTime: String?,
             distance: Double?,
             onlyPRO: Boolean?) -> Unit,
 ) {
   var maxPrice by remember { mutableStateOf(DEFAULT_MAX_PRICE) }
   var availablePlaces by remember { mutableStateOf<Int?>(null) }
   var minDate by remember { mutableStateOf<String?>(null) }
+  var maxDate by remember { mutableStateOf<String?>(null) }
   var minDateTimestamp by remember { mutableStateOf<Timestamp?>(null) }
-  var duration by remember { mutableStateOf<String?>(null) }
+  var maxDateTimestamp by remember { mutableStateOf<Timestamp?>(null) }
+  var startTime by remember { mutableStateOf<String?>(null) }
+  var endTime by remember { mutableStateOf<String?>(null) }
   var onlyPRO by remember { mutableStateOf<Boolean?>(false) }
   var distance by remember { mutableStateOf<String?>(null) }
 
@@ -54,6 +63,7 @@ fun FilterDialog(
                     .height(DIALOG_PADDING.dp)
                     .background(
                         color = Color.White, shape = RoundedCornerShape(size = MEDIUM_PADDING.dp))
+                    .verticalScroll(rememberScrollState())
                     .testTag("FilterDialog"),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -94,25 +104,70 @@ fun FilterDialog(
                     singleLine = true,
                     modifier = Modifier.testTag("membersAvailableTextField"),
                     shape = RoundedCornerShape(TEXT_PADDING.dp))
-
-                OutlinedTextField(
-                    value = minDate ?: "",
-                    onValueChange = { minDate = it },
-                    label = { Text("startDate") },
-                    modifier = Modifier.testTag("minDateTextField"),
-                    placeholder = {
-                      androidx.compose.material3.Text(
-                          text = stringResource(id = R.string.request_date_activity_withFormat))
-                    },
-                    singleLine = true,
-                    shape = RoundedCornerShape(TEXT_PADDING.dp))
-                OutlinedTextField(
-                    value = duration ?: "",
-                    onValueChange = { duration = it },
-                    label = { Text("Duration") },
-                    singleLine = true,
-                    modifier = Modifier.testTag("durationTextField"),
-                    shape = RoundedCornerShape(TEXT_PADDING.dp))
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = STANDARD_PADDING.dp),
+                    horizontalArrangement =
+                        Arrangement.SpaceBetween // Adjust spacing between text fields
+                    ) {
+                      OutlinedTextField(
+                          value = minDate ?: "",
+                          onValueChange = { minDate = it },
+                          label = { Text("StartDate") },
+                          modifier =
+                              Modifier.width(HALF_SCREEN_TEXT_FIELD_PADDING.dp)
+                                  .testTag("minDateTextField"),
+                          placeholder = {
+                            androidx.compose.material3.Text(
+                                text =
+                                    stringResource(id = R.string.request_date_activity_withFormat))
+                          },
+                          singleLine = true,
+                          shape = RoundedCornerShape(TEXT_PADDING.dp))
+                      OutlinedTextField(
+                          value = maxDate ?: "",
+                          onValueChange = { maxDate = it },
+                          label = { Text("DeadLine") },
+                          modifier =
+                              Modifier.width(HALF_SCREEN_TEXT_FIELD_PADDING.dp)
+                                  .testTag("maxDateTextField"),
+                          placeholder = {
+                            androidx.compose.material3.Text(
+                                text =
+                                    stringResource(id = R.string.request_date_activity_withFormat))
+                          },
+                          singleLine = true,
+                          shape = RoundedCornerShape(TEXT_PADDING.dp))
+                    }
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = STANDARD_PADDING.dp),
+                    horizontalArrangement =
+                        Arrangement.SpaceBetween // Adjust spacing between text fields
+                    ) {
+                      OutlinedTextField(
+                          value = startTime ?: "",
+                          onValueChange = { startTime = it },
+                          label = { Text("StartTime") },
+                          singleLine = true,
+                          modifier =
+                              Modifier.width(HALF_SCREEN_TEXT_FIELD_PADDING.dp)
+                                  .testTag("startTimeTextField"),
+                          shape = RoundedCornerShape(TEXT_PADDING.dp))
+                      OutlinedTextField(
+                          value = endTime ?: "",
+                          onValueChange = { endTime = it },
+                          label = { Text("EndTime") },
+                          singleLine = true,
+                          modifier =
+                              Modifier.width(HALF_SCREEN_TEXT_FIELD_PADDING.dp)
+                                  .testTag("endTimeTextField"),
+                          shape = RoundedCornerShape(TEXT_PADDING.dp))
+                    }
                 OutlinedTextField(
                     value = distance ?: "",
                     onValueChange = { distance = it },
@@ -161,11 +216,25 @@ fun FilterDialog(
                               0)
                           minDateTimestamp = Timestamp(calendar.time)
                         }
+                        if (maxDate != null) {
+                          val calendar = GregorianCalendar()
+                          val parts = maxDate!!.split("/")
+                          calendar.set(
+                              parts[2].toInt(),
+                              parts[1].toInt() - 1, // Months are 0-based
+                              parts[0].toInt(),
+                              0,
+                              0,
+                              0)
+                          maxDateTimestamp = Timestamp(calendar.time)
+                        }
                         onFilter(
                             maxPrice.toDouble(),
                             availablePlaces,
                             minDateTimestamp,
-                            duration,
+                            maxDateTimestamp,
+                            startTime,
+                            endTime,
                             distance?.toDouble(),
                             onlyPRO)
                         onDismiss()

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -119,11 +119,20 @@ fun ListActivitiesScreen(
                     price,
                     placesAvailable,
                     minDateTimestamp,
-                    acDuration,
+                    maxDateTimestamp,
+                    startTime,
+                    endTime,
                     distance,
                     seeOnlyPRO ->
                   viewModel.updateFilterState(
-                      price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO)
+                      price,
+                      placesAvailable,
+                      minDateTimestamp,
+                      maxDateTimestamp,
+                      startTime,
+                      endTime,
+                      distance,
+                      seeOnlyPRO)
                 })
           }
           Box(
@@ -196,7 +205,15 @@ fun ListActivitiesScreen(
                             (it.maxPlaces - it.placesLeft) <= viewModel.availablePlaces!!)
                             false
                         else if (viewModel.minDate != null && it.date < viewModel.minDate!!) false
-                        else if (viewModel.duration != null && it.duration != viewModel.duration)
+                        else if (viewModel.maxDate != null && it.date > viewModel.maxDate!!) false
+                        else if (viewModel.startTime != null &&
+                            hourDateViewModel.isBeginGreaterThanEnd(
+                                it.startTime, viewModel.startTime!!))
+                            false
+                        else if (viewModel.endTime != null &&
+                            hourDateViewModel.isBeginGreaterThanEnd(
+                                viewModel.endTime!!,
+                                hourDateViewModel.addDurationToTime(it.startTime, it.duration)))
                             false
                         else if (viewModel.distance != null &&
                             viewModel.distance!! <

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -115,9 +115,15 @@ fun ListActivitiesScreen(
           if (showFilterDialog) {
             FilterDialog(
                 onDismiss = { showFilterDialog = false },
-                onFilter = { price, placesAvailable, minDateTimestamp, acDuration, seeOnlyPRO ->
+                onFilter = {
+                    price,
+                    placesAvailable,
+                    minDateTimestamp,
+                    acDuration,
+                    distance,
+                    seeOnlyPRO ->
                   viewModel.updateFilterState(
-                      price, placesAvailable, minDateTimestamp, acDuration, seeOnlyPRO)
+                      price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO)
                 })
           }
           Box(
@@ -191,6 +197,10 @@ fun ListActivitiesScreen(
                             false
                         else if (viewModel.minDate != null && it.date < viewModel.minDate!!) false
                         else if (viewModel.duration != null && it.duration != viewModel.duration)
+                            false
+                        else if (viewModel.distance != null &&
+                            viewModel.distance!! <
+                                locationViewModel.getDistanceFromCurrentLocation(it.location)!!)
                             false
                         else if (viewModel.onlyPRO && it.type != ActivityType.PRO) false
                         else {

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -200,7 +200,8 @@ fun ListActivitiesScreen(
                             false
                         else if (viewModel.distance != null &&
                             viewModel.distance!! <
-                                locationViewModel.getDistanceFromCurrentLocation(it.location)!!)
+                            (locationViewModel.getDistanceFromCurrentLocation(it.location) ?: 0f)
+                        )
                             false
                         else if (viewModel.onlyPRO && it.type != ActivityType.PRO) false
                         else {

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -200,8 +200,8 @@ fun ListActivitiesScreen(
                             false
                         else if (viewModel.distance != null &&
                             viewModel.distance!! <
-                            (locationViewModel.getDistanceFromCurrentLocation(it.location) ?: 0f)
-                        )
+                                (locationViewModel.getDistanceFromCurrentLocation(it.location)
+                                    ?: 0f))
                             false
                         else if (viewModel.onlyPRO && it.type != ActivityType.PRO) false
                         else {

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -47,6 +47,7 @@ import com.android.sample.R
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.hour_date.HourDateViewModel
 import com.android.sample.model.map.HandleLocationPermissionsAndTracking
 import com.android.sample.model.map.LocationViewModel
 import com.android.sample.model.network.NetworkManager
@@ -89,6 +90,7 @@ fun MapScreen(
   var showBottomSheet by remember { mutableStateOf(false) }
   val previousScreen = navigationActions.getPreviousRoute()
   var showFilterDialog by remember { mutableStateOf(false) }
+  val hourDateViewModel: HourDateViewModel = HourDateViewModel()
   HandleLocationPermissionsAndTracking(locationViewModel = locationViewModel)
 
   val firstLocation =
@@ -158,8 +160,17 @@ fun MapScreen(
                         else if (listActivitiesViewModel.minDate != null &&
                             it.date < listActivitiesViewModel.minDate!!)
                             false
-                        else if (listActivitiesViewModel.duration != null &&
-                            it.duration != listActivitiesViewModel.duration)
+                        else if (listActivitiesViewModel.maxDate != null &&
+                            it.date > listActivitiesViewModel.maxDate!!)
+                            false
+                        else if (listActivitiesViewModel.startTime != null &&
+                            hourDateViewModel.isBeginGreaterThanEnd(
+                                it.startTime, listActivitiesViewModel.startTime!!))
+                            false
+                        else if (listActivitiesViewModel.endTime != null &&
+                            hourDateViewModel.isBeginGreaterThanEnd(
+                                listActivitiesViewModel.endTime!!,
+                                hourDateViewModel.addDurationToTime(it.startTime, it.duration)))
                             false
                         else if (listActivitiesViewModel.distance != null &&
                             listActivitiesViewModel.distance!! <
@@ -215,9 +226,24 @@ fun MapScreen(
   if (showFilterDialog) {
     FilterDialog(
         onDismiss = { showFilterDialog = false },
-        onFilter = { price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO ->
+        onFilter = {
+            price,
+            placesAvailable,
+            minDateTimestamp,
+            maxDateTimestamp,
+            startTime,
+            endTime,
+            distance,
+            seeOnlyPRO ->
           listActivitiesViewModel.updateFilterState(
-              price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO)
+              price,
+              placesAvailable,
+              minDateTimestamp,
+              maxDateTimestamp,
+              startTime,
+              endTime,
+              distance,
+              seeOnlyPRO)
         })
   }
   if (showBottomSheet) {

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -161,6 +161,10 @@ fun MapScreen(
                         else if (listActivitiesViewModel.duration != null &&
                             it.duration != listActivitiesViewModel.duration)
                             false
+                        else if (listActivitiesViewModel.distance != null &&
+                            listActivitiesViewModel.distance!! <
+                                locationViewModel.getDistanceFromCurrentLocation(it.location)!!)
+                            false
                         else if (listActivitiesViewModel.onlyPRO && it.type != ActivityType.PRO)
                             false
                         else it.location != null
@@ -211,9 +215,9 @@ fun MapScreen(
   if (showFilterDialog) {
     FilterDialog(
         onDismiss = { showFilterDialog = false },
-        onFilter = { price, placesAvailable, minDateTimestamp, acDuration, seeOnlyPRO ->
+        onFilter = { price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO ->
           listActivitiesViewModel.updateFilterState(
-              price, placesAvailable, minDateTimestamp, acDuration, seeOnlyPRO)
+              price, placesAvailable, minDateTimestamp, acDuration, distance, seeOnlyPRO)
         })
   }
   if (showBottomSheet) {


### PR DESCRIPTION
This pull request introduces significant changes to the `FilterDialog` and its associated tests to include additional filtering options such as `maxDate`, `startTime`, `endTime`, and `distance`. It also updates related ViewModel and UI components to support these new filters.

### Changes to FilterDialog and Tests:

* `FilterDialog` now includes new filtering options: `maxDate`, `startTime`, `endTime`, and `distance`. These changes are reflected in the dialog's UI and the `onFilter` callback. [[1]](diffhunk://#diff-28cbbc788e3284f34c3bd4d59105e251e712b6bca77fa1f2e0593d02b555d0c3L35-R55) [[2]](diffhunk://#diff-28cbbc788e3284f34c3bd4d59105e251e712b6bca77fa1f2e0593d02b555d0c3R66)
* Updated `FilterDialogTest` to test the new filtering options. Added assertions for `maxDate`, `startTime`, `endTime`, and `distance` fields, ensuring they are displayed and can be interacted with. [[1]](diffhunk://#diff-cfcf6b016ebddc8d70f481104c89ebc450ebd8e9fef0c2bf0c303caa542ce580L21-R31) [[2]](diffhunk://#diff-cfcf6b016ebddc8d70f481104c89ebc450ebd8e9fef0c2bf0c303caa542ce580L51-R57) [[3]](diffhunk://#diff-cfcf6b016ebddc8d70f481104c89ebc450ebd8e9fef0c2bf0c303caa542ce580L62-R70) [[4]](diffhunk://#diff-cfcf6b016ebddc8d70f481104c89ebc450ebd8e9fef0c2bf0c303caa542ce580L72-R136) [[5]](diffhunk://#diff-cfcf6b016ebddc8d70f481104c89ebc450ebd8e9fef0c2bf0c303caa542ce580L102-R181)

### Changes to ViewModel:

* Modified `ListActivitiesViewModel` to include new state variables for `maxDate`, `startTime`, `endTime`, and `distance`. Updated the `updateFilterState` method to handle these new variables. [[1]](diffhunk://#diff-b58b26be32e996bbb8e363fd3a9b6c10fdca142ceac60837596e81a521eddaf0L41-R45) [[2]](diffhunk://#diff-b58b26be32e996bbb8e363fd3a9b6c10fdca142ceac60837596e81a521eddaf0L60-R77)

### Changes to Test Cases:

* Updated `ListActivitiesTest` to reflect the new filtering logic. Renamed and modified test cases to check filtering by `maxDate`, `startTime`, and `endTime` instead of duration. [[1]](diffhunk://#diff-8892711245d70022b9debe0b8d2f2fdf9fdf154b5ee42bfa2c3080c4b5375e4cL524-R539) [[2]](diffhunk://#diff-8892711245d70022b9debe0b8d2f2fdf9fdf154b5ee42bfa2c3080c4b5375e4cL543-R610) [[3]](diffhunk://#diff-8892711245d70022b9debe0b8d2f2fdf9fdf154b5ee42bfa2c3080c4b5375e4cL560-R627)

### Additional Changes:

* Added constants for UI padding in `C.kt` to support the new layout adjustments in `FilterDialog`.
* Imported additional Compose UI components to support scrolling in the `FilterDialog`. [[1]](diffhunk://#diff-28cbbc788e3284f34c3bd4d59105e251e712b6bca77fa1f2e0593d02b555d0c3R5-R9) [[2]](diffhunk://#diff-28cbbc788e3284f34c3bd4d59105e251e712b6bca77fa1f2e0593d02b555d0c3R24)