### PR TITLE
fix: remove duplicated code

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -368,24 +368,6 @@ fun CreateActivityScreen(
                             .testTag("inputLocationCreate"),
                     singleLine = true)
 
-                locationSuggestions.filterNotNull().take(3).forEach { location ->
-                  DropdownMenuItem(
-                      text = {
-                        Text(
-                            text =
-                                location.name.take(TOP_TITLE_SIZE) +
-                                    if (location.name.length > TOP_TITLE_SIZE) "..."
-                                    else "", // Limit name length
-                            maxLines = 1 // Ensure name doesn't overflow
-                            )
-                      },
-                      onClick = {
-                        locationViewModel.setQuery(location.name)
-                        selectedLocation = location
-                        showDropdown = false // Close dropdown on selection
-                      },
-                      modifier = Modifier.padding(STANDARD_PADDING.dp))
-                }
                 // Dropdown menu for location suggestions
                 DropdownMenu(
                     expanded = showDropdown && locationSuggestions.isNotEmpty(),
@@ -396,8 +378,8 @@ fun CreateActivityScreen(
                             text = {
                               Text(
                                   text =
-                                      location.name.take(30) +
-                                          if (location.name.length > 30) "..."
+                                      location.name.take(TOP_TITLE_SIZE) +
+                                          if (location.name.length > TOP_TITLE_SIZE) "..."
                                           else "", // Limit name length
                                   maxLines = 1 // Ensure name doesn't overflow
                                   )


### PR DESCRIPTION
Very simple PR with a codebase simplification:
* Removed redundant `DropdownMenuItem` creation for location suggestions.
* Replaced hardcoded `30` with `TOP_TITLE_SIZE` constant for limiting location name length.

This was causing a UI bug in the location selection process, which stopped us from correctly creating an activity.

Closes #345 