### PR TITLE
Fix date and hour filtering for activities in profile

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.hour_date.HourDateViewModel
 import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.network.NetworkManager
 import com.android.sample.model.profile.ProfileViewModel
@@ -192,12 +193,18 @@ fun ProfileContent(
                   activitiesList.filter {
                     it.creator == user.id || it.participants.map { it.id }.contains(user.id)
                   }
-
+              val hourDateViewModel = HourDateViewModel()
               // Display activities sections
               displayActivitySection(
                   "Activities Created",
                   "created",
-                  usersActivity.filter { it.creator == user.id && it.date > Timestamp.now() },
+                  usersActivity.filter {
+                    it.creator == user.id &&
+                        hourDateViewModel.combineDateAndTime(
+                            it.date,
+                            hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
+                            Timestamp.now()
+                  },
                   navigationActions,
                   userProfileViewModel,
                   listActivitiesViewModel,
@@ -206,7 +213,13 @@ fun ProfileContent(
               displayActivitySection(
                   "Activities Enrolled in",
                   "enrolled",
-                  usersActivity.filter { it.creator != user.id && it.date > Timestamp.now() },
+                  usersActivity.filter {
+                    it.creator != user.id &&
+                        hourDateViewModel.combineDateAndTime(
+                            it.date,
+                            hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
+                            Timestamp.now()
+                  },
                   navigationActions,
                   userProfileViewModel,
                   listActivitiesViewModel,
@@ -215,7 +228,11 @@ fun ProfileContent(
               displayActivitySection(
                   "Past Activities",
                   "past",
-                  usersActivity.filter { it.date <= Timestamp.now() },
+                  usersActivity.filter {
+                    hourDateViewModel.combineDateAndTime(
+                        it.date, hourDateViewModel.addDurationToTime(it.startTime, it.duration)) <=
+                        Timestamp.now()
+                  },
                   navigationActions,
                   userProfileViewModel,
                   listActivitiesViewModel,


### PR DESCRIPTION
This pull request includes changes to the `Profile.kt` file in order to enhance the handling of activity dates and times. The most important changes involve importing the `HourDateViewModel` and utilizing its methods to combine dates and times for filtering activities.

Key changes:

* `Profile.kt`:
  * Imported `HourDateViewModel` to handle date and time operations.
  * Added an instance of `HourDateViewModel` in the `ProfileContent` function.
  * Updated the filter logic for "Activities Created" to use `combineDateAndTime` and `addDurationToTime` methods from `HourDateViewModel`.
  * Updated the filter logic for "Activities Enrolled in" to use `combineDateAndTime` and `addDurationToTime` methods from `HourDateViewModel`.
  * Updated the filter logic for "Past Activities" to use `combineDateAndTime` and `addDurationToTime` methods from `HourDateViewModel`.
 
______________________________________________________________________________________________________________________________

Side note: This task was correctly implemented by @aminebenji04 but since I changed the profile screen implementation there were merge conflicts and solving them, the changes made by my team mate were overriten. This PR serves to adapt the changes he made to my new implementation 