### PR TITLE
Fix time and date pickers can't re-open on dismiss

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/components/DatePickerTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/components/DatePickerTest.kt
@@ -13,7 +13,7 @@ class DatePickerTest {
   @Test
   fun datePicker_disallowsPastDates() {
     composeTestRule.setContent {
-      MyDatePicker(onDateSelected = {}, isOpen = true, initialDate = null)
+      MyDatePicker(onDateSelected = {}, isOpen = true, initialDate = null, onCloseRequest = {})
     }
 
     val pastDate = LocalDate.now().minusDays(2)
@@ -23,7 +23,7 @@ class DatePickerTest {
   @Test
   fun datePicker_isDisplayed() {
     composeTestRule.setContent {
-      MyDatePicker(onDateSelected = {}, isOpen = true, initialDate = null)
+      MyDatePicker(onDateSelected = {}, isOpen = true, initialDate = null, onCloseRequest = {})
     }
     composeTestRule.onNodeWithText("Select a date").assertExists()
   }
@@ -31,7 +31,7 @@ class DatePickerTest {
   @Test
   fun datePicker_isNotDisplayed() {
     composeTestRule.setContent {
-      MyDatePicker(onDateSelected = {}, isOpen = false, initialDate = null)
+      MyDatePicker(onDateSelected = {}, isOpen = false, initialDate = null, onCloseRequest = {})
     }
     composeTestRule.onNodeWithText("Select a date").assertDoesNotExist()
   }

--- a/app/src/androidTest/java/com/android/sample/ui/components/TimePickerTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/components/TimePickerTest.kt
@@ -10,14 +10,14 @@ class TimePickerTest {
 
   @Test
   fun testMyTimePicker_isDisplayed() {
-    composeTestRule.setContent { MyTimePicker(onTimeSelected = {}, isOpen = true) }
+    composeTestRule.setContent { MyTimePicker(onTimeSelected = {}, isOpen = true, onCloseRequest = {}) }
     // Check if dialog opens with correct title
     composeTestRule.onNodeWithText("Pick a time").assertExists()
   }
 
   @Test
   fun testMyPicker_isNotDisplayed() {
-    composeTestRule.setContent { MyTimePicker(onTimeSelected = {}, isOpen = false) }
+    composeTestRule.setContent { MyTimePicker(onTimeSelected = {}, isOpen = false, onCloseRequest = {}) }
     // Check if dialog is not displayed
     composeTestRule.onNodeWithText("Pick a time").assertDoesNotExist()
   }

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -258,13 +258,14 @@ fun CreateActivityScreen(
               }
               if (dateIsOpen) {
                 MyDatePicker(
+                    onCloseRequest = { dateIsOpen = false },
                     onDateSelected = { date ->
                       dueDate = date
                       dateIsOpen = false
                       dateIsSet = true
                     },
                     isOpen = dateIsOpen,
-                    null)
+                    initialDate = null)
               }
               Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))
               OutlinedButton(
@@ -290,7 +291,8 @@ fun CreateActivityScreen(
                       startTimeIsOpen = false
                       startTimeIsSet = true
                     },
-                    isOpen = startTimeIsOpen)
+                    isOpen = startTimeIsOpen,
+                    onCloseRequest = { startTimeIsOpen = false })
               }
 
               Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))
@@ -319,7 +321,8 @@ fun CreateActivityScreen(
                       durationIsOpen = false
                       durationIsSet = true
                     },
-                    isOpen = durationIsOpen)
+                    isOpen = durationIsOpen,
+                    onCloseRequest = { durationIsOpen = false })
               }
               Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))
 

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -243,6 +243,7 @@ fun EditActivityScreen(
             }
             if (dateIsOpen) {
               MyDatePicker(
+                  onCloseRequest = { dateIsOpen = false },
                   onDateSelected = { date ->
                     dueDate = date
                     dateIsOpen = false
@@ -284,6 +285,7 @@ fun EditActivityScreen(
                     timeIsOpen = false
                   },
                   isOpen = timeIsOpen,
+                  onCloseRequest = { timeIsOpen = false },
               )
             }
             Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))
@@ -312,6 +314,7 @@ fun EditActivityScreen(
                     durationIsOpen = false
                   },
                   isOpen = durationIsOpen,
+                  onCloseRequest = { durationIsOpen = false },
               )
             }
             Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))

--- a/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
@@ -3,14 +3,16 @@ package com.android.sample.ui.components
 import androidx.compose.runtime.Composable
 import com.google.firebase.Timestamp
 import com.vanpra.composematerialdialogs.MaterialDialog
+import com.vanpra.composematerialdialogs.MaterialDialogState
 import com.vanpra.composematerialdialogs.datetime.date.datepicker
 import com.vanpra.composematerialdialogs.rememberMaterialDialogState
 import java.time.LocalDate
 import java.time.ZoneOffset
 
 @Composable
-fun MyDatePicker(onDateSelected: (Timestamp) -> Unit, isOpen: Boolean, initialDate: LocalDate?) {
+fun MyDatePicker(onDateSelected: (Timestamp) -> Unit, isOpen: Boolean, initialDate: LocalDate?, onCloseRequest: (MaterialDialogState) -> Unit) {
   MaterialDialog(
+      onCloseRequest = onCloseRequest,
       dialogState = rememberMaterialDialogState(isOpen),
       buttons = {
         positiveButton("Ok")

--- a/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
@@ -19,7 +19,7 @@ fun MyTimePicker(onTimeSelected: (Timestamp) -> Unit, isOpen: Boolean, onCloseRe
         negativeButton(text = "Cancel")
       }) {
         timepicker(
-            initialTime = LocalTime.NOON,
+            initialTime = LocalTime.now().truncatedTo(java.time.temporal.ChronoUnit.MINUTES),
             title = "Pick a time",
         ) {
           onTimeSelected(

--- a/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
@@ -3,14 +3,16 @@ package com.android.sample.ui.components
 import androidx.compose.runtime.Composable
 import com.google.firebase.Timestamp
 import com.vanpra.composematerialdialogs.MaterialDialog
+import com.vanpra.composematerialdialogs.MaterialDialogState
 import com.vanpra.composematerialdialogs.datetime.time.timepicker
 import com.vanpra.composematerialdialogs.rememberMaterialDialogState
 import java.time.LocalDate
 import java.time.LocalTime
 
 @Composable
-fun MyTimePicker(onTimeSelected: (Timestamp) -> Unit, isOpen: Boolean) {
+fun MyTimePicker(onTimeSelected: (Timestamp) -> Unit, isOpen: Boolean, onCloseRequest: (MaterialDialogState) -> Unit) {
   MaterialDialog(
+      onCloseRequest = onCloseRequest,
       dialogState = rememberMaterialDialogState(isOpen),
       buttons = {
         positiveButton(text = "Ok")

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -202,7 +202,7 @@ fun ProfileContent(
                     it.creator == user.id &&
                         hourDateViewModel.combineDateAndTime(
                             it.date,
-                            hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
+                            it.startTime) >
                             Timestamp.now()
                   },
                   navigationActions,
@@ -217,7 +217,7 @@ fun ProfileContent(
                     it.creator != user.id &&
                         hourDateViewModel.combineDateAndTime(
                             it.date,
-                            hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
+                            it.startTime) >
                             Timestamp.now()
                   },
                   navigationActions,
@@ -230,7 +230,7 @@ fun ProfileContent(
                   "past",
                   usersActivity.filter {
                     hourDateViewModel.combineDateAndTime(
-                        it.date, hourDateViewModel.addDurationToTime(it.startTime, it.duration)) <=
+                        it.date, it.startTime) <=
                         Timestamp.now()
                   },
                   navigationActions,


### PR DESCRIPTION
This pull request includes several changes to the `DatePicker` and `TimePicker` components, as well as updates to their usage in various parts of the application. The primary goal is to add an `onCloseRequest` parameter to these components to handle closing events more effectively.

Changes to `DatePicker` and `TimePicker` components:

* [`app/src/main/java/com/android/sample/ui/components/DatePicker.kt`](diffhunk://#diff-e80beb97f75e27602d3244da282bfdb75b9b48e9945596c6bb03bd47e2b07ac6R6-R15): Added `onCloseRequest` parameter to `MyDatePicker` function to handle dialog close events.
* [`app/src/main/java/com/android/sample/ui/components/TimePicker.kt`](diffhunk://#diff-2f72a5325557db7b590505bc96bcbf5fc1d204d50a62e3b2ce761b5b4dcb9762R6-R22): Added `onCloseRequest` parameter to `MyTimePicker` function to handle dialog close events.

Updates to tests:

* [`app/src/androidTest/java/com/android/sample/ui/components/DatePickerTest.kt`](diffhunk://#diff-f54318cbe6aaf5a003def90144119db21d74a179a37cf4246c98922d25c76a3fL16-R16): Updated tests to include the new `onCloseRequest` parameter in `MyDatePicker` function calls. [[1]](diffhunk://#diff-f54318cbe6aaf5a003def90144119db21d74a179a37cf4246c98922d25c76a3fL16-R16) [[2]](diffhunk://#diff-f54318cbe6aaf5a003def90144119db21d74a179a37cf4246c98922d25c76a3fL26-R34)
* [`app/src/androidTest/java/com/android/sample/ui/components/TimePickerTest.kt`](diffhunk://#diff-d3a8e5ab4b800354e7a313f954c2318cc530eaadd19f180679bf80d8b26bf1deL13-R20): Updated tests to include the new `onCloseRequest` parameter in `MyTimePicker` function calls.

Usage updates in activity screens:

* [`app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt`](diffhunk://#diff-38c302af30fc7257980234ed59aed91589cb302671f5734b59e740044b451e8aR262-R269): Updated `MyDatePicker` and `MyTimePicker` calls to include the `onCloseRequest` parameter for handling dialog close events. [[1]](diffhunk://#diff-38c302af30fc7257980234ed59aed91589cb302671f5734b59e740044b451e8aR262-R269) [[2]](diffhunk://#diff-38c302af30fc7257980234ed59aed91589cb302671f5734b59e740044b451e8aL294-R296) [[3]](diffhunk://#diff-38c302af30fc7257980234ed59aed91589cb302671f5734b59e740044b451e8aL323-R326)
* [`app/src/main/java/com/android/sample/ui/activity/EditActivity.kt`](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144R247): Updated `MyDatePicker` and `MyTimePicker` calls to include the `onCloseRequest` parameter for handling dialog close events. [[1]](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144R247) [[2]](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144R289) [[3]](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144R318)

Minor changes in `Profile.kt`:

* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L205-R205): Simplified time comparison logic by removing the call to `addDurationToTime` and directly using `startTime`. [[1]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L205-R205) [[2]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L220-R220) [[3]](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L233-R233)