### PR TITLE
Fix navigation to navigate to profile when deleting an activtiy

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -615,7 +615,7 @@ fun EditActivityScreen(
                         Log.e("EditActivityScreen", "Failed to remove images: ${error.message}")
                       })
 
-                  navigationActions.navigateTo(Screen.OVERVIEW)
+                  navigationActions.navigateTo(Screen.PROFILE)
                 },
                 modifier =
                     Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp).testTag("deleteButton"),


### PR DESCRIPTION
This pull request includes a change to the `EditActivityScreen` function in the `EditActivity.kt` file. The change modifies the navigation action after an image removal operation.

* [`app/src/main/java/com/android/sample/ui/activity/EditActivity.kt`](diffhunk://#diff-cea2a1072c58261b4a239e412749fe81981de842d5e34d63e75f8bec747c3144L618-R618): Changed the navigation destination from `Screen.OVERVIEW` to `Screen.PROFILE` after the image removal operation.
* Even if the coverage on new code is equal to zero is because the new code (one line) hasn't been tested but the class has over 80% coverage

__________________________________________________________________________________________________________________________________________

Closes issue #343 