### PR TITLE
Refactor Profile Creation Screen to Match Figma Designs

### DIFF
--- a/app/src/main/java/com/android/sample/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/sample/model/activity/Activity.kt
@@ -4,6 +4,10 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.android.sample.model.map.Location
 import com.android.sample.model.profile.User
+import com.android.sample.resources.C.Tag.CULTURE_COLOR
+import com.android.sample.resources.C.Tag.ENTERTAINMENT_COLOR
+import com.android.sample.resources.C.Tag.SKILLS_COLOR
+import com.android.sample.resources.C.Tag.SPORT_COLOR
 import com.google.firebase.Timestamp
 
 @Entity(tableName = "activities")
@@ -57,3 +61,10 @@ enum class Category {
 }
 
 val categories = Category.values().toList()
+val CategoryColorMap =
+    mapOf(
+        Category.SPORT to SPORT_COLOR,
+        Category.CULTURE to CULTURE_COLOR,
+        Category.SKILLS to SKILLS_COLOR,
+        Category.ENTERTAINMENT to ENTERTAINMENT_COLOR,
+    )

--- a/app/src/main/java/com/android/sample/model/profile/User.kt
+++ b/app/src/main/java/com/android/sample/model/profile/User.kt
@@ -1,7 +1,14 @@
 package com.android.sample.model.profile
 
+import androidx.compose.ui.graphics.Color
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.android.sample.resources.C.Tag.ART_ACTIVITY_COLOR
+import com.android.sample.resources.C.Tag.CULTURAL_ACTIVITY_COLOR
+import com.android.sample.resources.C.Tag.INDOOR_COLOR
+import com.android.sample.resources.C.Tag.MUSICAL_ACTIVITY_COLOR
+import com.android.sample.resources.C.Tag.OUTDOOR_COLOR
+import com.android.sample.resources.C.Tag.SPORT_COLOR
 
 @Entity(tableName = "User")
 data class User(
@@ -24,3 +31,12 @@ val InterestCategories =
         "Cultural Activity",
         "Art Activity",
         "Musical Activity") + "None"
+val InterestCategoriesColors =
+    mapOf(
+        "Sport" to SPORT_COLOR,
+        "Outdoor Activity" to OUTDOOR_COLOR,
+        "Indoor Activity" to INDOOR_COLOR,
+        "Cultural Activity" to CULTURAL_ACTIVITY_COLOR,
+        "Art Activity" to ART_ACTIVITY_COLOR,
+        "Musical Activity" to MUSICAL_ACTIVITY_COLOR,
+        "None" to Color.Gray)

--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -1,5 +1,6 @@
 package com.android.sample.resources
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -89,5 +90,16 @@ object C {
     const val BORDER_STROKE_SM = 1
     // errors
     const val OFFLINE_TOAST_MESSAGE = "You are offline. Action not allowed."
+
+    // colors categories
+    val SPORT_COLOR = Color(0xFFC0EDAD)
+    val CULTURE_COLOR = Color(0xFFD0B0E0)
+    val SKILLS_COLOR = Color(0xFFC8E7F2)
+    val OUTDOOR_COLOR = Color(0xFFC8E7F2)
+    val INDOOR_COLOR = Color(0xFFE8D8C9)
+    val ENTERTAINMENT_COLOR = Color(0xFFFFCE7A)
+    val CULTURAL_ACTIVITY_COLOR = Color(0xFFFFCE7A)
+    val MUSICAL_ACTIVITY_COLOR = Color(0xFFFBF2C4)
+    val ART_ACTIVITY_COLOR = Color(0xFFE4BABE)
   }
 }

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -147,7 +147,7 @@ fun TextFieldWithErrorState(
     modifier: Modifier = Modifier,
     validation: (String) -> String?,
     externalError: String? = null,
-    testTag : String? = null,
+    testTag: String? = null,
     errorTestTag: String
 ) {
   var internalError by remember { mutableStateOf<String?>(null) }
@@ -171,7 +171,7 @@ fun TextFieldWithErrorState(
                 },
                 label = { Text(label) },
                 isError = error != null,
-                modifier = Modifier.fillMaxWidth().testTag(testTag  ?: "TextFieldWithErrorState"),
+                modifier = Modifier.fillMaxWidth().testTag(testTag ?: "TextFieldWithErrorState"),
                 shape = RoundedCornerShape(BORDER_STROKE_SM.dp),
                 colors =
                     TextFieldDefaults.colors(

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -147,6 +147,7 @@ fun TextFieldWithErrorState(
     modifier: Modifier = Modifier,
     validation: (String) -> String?,
     externalError: String? = null,
+    testTag : String? = null,
     errorTestTag: String
 ) {
   var internalError by remember { mutableStateOf<String?>(null) }
@@ -154,7 +155,7 @@ fun TextFieldWithErrorState(
   // Show external error if present, otherwise use internal error
   val error = externalError ?: internalError
 
-  Column(modifier = Modifier.fillMaxWidth(WIDTH_FRACTION_MD)) {
+  Column(modifier = modifier) {
     Card(
         modifier = Modifier.fillMaxWidth().testTag("TextFieldWithErrorStateCard"),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
@@ -170,7 +171,7 @@ fun TextFieldWithErrorState(
                 },
                 label = { Text(label) },
                 isError = error != null,
-                modifier = modifier,
+                modifier = Modifier.fillMaxWidth().testTag(testTag  ?: "TextFieldWithErrorState"),
                 shape = RoundedCornerShape(BORDER_STROKE_SM.dp),
                 colors =
                     TextFieldDefaults.colors(
@@ -179,7 +180,8 @@ fun TextFieldWithErrorState(
                         focusedIndicatorColor = Color.Transparent,
                         unfocusedIndicatorColor = Color.Transparent,
                         errorIndicatorColor = Color.Transparent,
-                        errorContainerColor = Color.Transparent))
+                        errorContainerColor = Color.Transparent),
+                singleLine = true)
           }
         }
     error?.let {

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -159,7 +159,7 @@ fun TextFieldWithErrorState(
     Card(
         modifier = Modifier.fillMaxWidth().testTag("TextFieldWithErrorStateCard"),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION_DEFAULT.dp),
         shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp),
         border = if (error != null) BorderStroke(BORDER_STROKE_SM.dp, Color.Red) else null) {
           Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 0.dp, vertical = 0.dp)) {

--- a/app/src/main/java/com/android/sample/ui/components/Textfields.kt
+++ b/app/src/main/java/com/android/sample/ui/components/Textfields.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.unit.dp
 import com.android.sample.resources.C.Tag.BORDER_STROKE_SM
 import com.android.sample.resources.C.Tag.CARD_ELEVATION_DEFAULT
 import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_FONT_SIZE
-import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_START
-import com.android.sample.resources.C.Tag.ERROR_TEXTFIELD_PADDING_TOP
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
 import com.android.sample.resources.C.Tag.WIDTH_FRACTION_MD
@@ -156,24 +154,41 @@ fun TextFieldWithErrorState(
   // Show external error if present, otherwise use internal error
   val error = externalError ?: internalError
 
-  Column() {
-    OutlinedTextField(
-        value = value,
-        onValueChange = { newValue ->
-          onValueChange(newValue)
-          internalError = validation(newValue)
-        },
-        label = { Text(label) },
-        isError = error != null,
-        modifier = modifier)
+  Column(modifier = Modifier.fillMaxWidth(WIDTH_FRACTION_MD)) {
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("TextFieldWithErrorStateCard"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp),
+        border = if (error != null) BorderStroke(BORDER_STROKE_SM.dp, Color.Red) else null) {
+          Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 0.dp, vertical = 0.dp)) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = { newValue ->
+                  onValueChange(newValue)
+                  internalError = validation(newValue)
+                },
+                label = { Text(label) },
+                isError = error != null,
+                modifier = modifier,
+                shape = RoundedCornerShape(BORDER_STROKE_SM.dp),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        errorIndicatorColor = Color.Transparent,
+                        errorContainerColor = Color.Transparent))
+          }
+        }
     error?.let {
       Text(
           text = it,
           color = Color.Red,
           fontSize = ERROR_TEXTFIELD_FONT_SIZE,
           modifier =
-              Modifier.align(Alignment.Start)
-                  .padding(start = ERROR_TEXTFIELD_PADDING_START, top = ERROR_TEXTFIELD_PADDING_TOP)
+              Modifier.padding(start = MEDIUM_PADDING.dp, top = (MEDIUM_PADDING / 2).dp)
                   .testTag(errorTestTag))
     }
   }

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -25,14 +25,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -52,11 +56,12 @@ import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.network.NetworkManager
 import com.android.sample.model.profile.Interest
 import com.android.sample.model.profile.InterestCategories
+import com.android.sample.model.profile.InterestCategoriesColors
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
-import com.android.sample.resources.C.Tag.LARGE_IMAGE_SIZE
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
+import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.SUBTITLE_FONTSIZE
 import com.android.sample.ui.camera.CameraScreen
@@ -272,85 +277,158 @@ fun ManageInterests(initialInterests: List<Interest>, onUpdateInterests: (List<I
   val context = LocalContext.current
   val networkManager = NetworkManager(context)
 
-  Row(verticalAlignment = Alignment.CenterVertically) {
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
-      OutlinedTextField(
-          value = selectedCategory,
-          onValueChange = { selectedCategory = it },
-          label = { Text("Category") },
-          readOnly = true,
-          modifier = Modifier.menuAnchor().width(LARGE_IMAGE_SIZE.dp).testTag("categoryDropdown"))
+  Column(
+      modifier = Modifier.fillMaxWidth(),
+      verticalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        // Input Row
+        InterestInputRow(
+            categories = InterestCategories,
+            selectedCategory = selectedCategory,
+            onCategoryChange = { selectedCategory = it },
+            expanded = expanded,
+            onExpandChange = { expanded = !expanded },
+            newInterest = newInterest,
+            onInterestChange = { newInterest = it })
+        Spacer(Modifier.height(STANDARD_PADDING.dp))
+        // Add Button
 
-      ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-        categories.forEach { category ->
-          DropdownMenuItem(
-              text = { Text(category) },
-              onClick = {
-                selectedCategory = category
-                expanded = false
-              })
-        }
-      }
-    }
-
-    OutlinedTextField(
-        value = newInterest,
-        onValueChange = { newInterest = it },
-        label = { Text("New Interest") },
-        enabled = selectedCategory.isNotEmpty() && selectedCategory != "None",
-        modifier = Modifier.width(LARGE_IMAGE_SIZE.dp).testTag("newInterestInput"))
-  }
-
-  Row(verticalAlignment = Alignment.CenterVertically) {
-    Button(
-        onClick = {
-          performOfflineAwareAction(
-              context = context,
-              networkManager = networkManager,
-              onPerform = {
-                if (newInterest.isNotBlank() &&
-                    selectedCategory.isNotBlank() &&
-                    selectedCategory != "None") {
-                  val updatedList = newListInterests + Interest(selectedCategory, newInterest)
-                  newListInterests = updatedList
-                  newInterest = ""
-                  selectedCategory = ""
-                  onUpdateInterests(updatedList)
-                }
-              })
-        },
-        enabled =
-            newInterest.isNotBlank() && selectedCategory.isNotBlank() && selectedCategory != "None",
-        modifier = Modifier.testTag("addInterestButton")) {
-          Text("Add")
-        }
-  }
-
-  LazyRow(
-      modifier = Modifier.testTag("interestsList"),
-      horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
-        items(newListInterests.size) { interest ->
-          InterestEditBox(
-              interest = newListInterests[interest].interest,
-              onRemove = {
-                performOfflineAwareAction(
-                    context = context,
-                    networkManager = networkManager,
-                    onPerform = {
-                      val updatedList = newListInterests - newListInterests[interest]
-                      newListInterests = updatedList
-                      onUpdateInterests(updatedList)
+        // Interests List
+        LazyRow(
+            modifier = Modifier.testTag("interestsList"),
+            horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
+              items(newListInterests.size) { interest ->
+                InterestEditBox(
+                    category = newListInterests[interest].category,
+                    interest = newListInterests[interest].interest,
+                    onRemove = {
+                      performOfflineAwareAction(
+                          context = context,
+                          networkManager = networkManager,
+                          onPerform = {
+                            val updatedList = newListInterests - newListInterests[interest]
+                            newListInterests = updatedList
+                            onUpdateInterests(updatedList)
+                          })
                     })
-              })
-        }
+              }
+            }
+        Button(
+            onClick = {
+              performOfflineAwareAction(
+                  context = context,
+                  networkManager = networkManager,
+                  onPerform = {
+                    if (newInterest.isNotBlank() &&
+                        selectedCategory.isNotBlank() &&
+                        selectedCategory != "None") {
+                      val updatedList = newListInterests + Interest(selectedCategory, newInterest)
+                      newListInterests = updatedList
+                      newInterest = ""
+                      selectedCategory = ""
+                      onUpdateInterests(updatedList)
+                    }
+                  })
+            },
+            enabled =
+                newInterest.isNotBlank() &&
+                    selectedCategory.isNotBlank() &&
+                    selectedCategory != "None",
+            modifier = Modifier.testTag("addInterestButton"),
+            shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
+              Text("Add Interest")
+            }
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InterestInputRow(
+    categories: List<String>,
+    selectedCategory: String,
+    onCategoryChange: (String) -> Unit,
+    expanded: Boolean,
+    onExpandChange: (Boolean) -> Unit,
+    newInterest: String,
+    onInterestChange: (String) -> Unit
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
+        // Category Dropdown
+        Card(
+            modifier = Modifier.weight(1f).testTag("TextFieldWithErrorStateCard"),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
+              ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = onExpandChange) {
+                OutlinedTextField(
+                    value = selectedCategory,
+                    onValueChange = { onCategoryChange(it) },
+                    label = { Text("Category") },
+                    readOnly = true,
+                    modifier = Modifier.menuAnchor().testTag("categoryDropdown"),
+                    colors =
+                        TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            errorIndicatorColor = Color.Transparent,
+                            errorContainerColor = Color.Transparent))
+
+                ExposedDropdownMenu(
+                    expanded = expanded, onDismissRequest = { onExpandChange(false) }) {
+                      categories.forEach { category ->
+                        DropdownMenuItem(
+                            text = { Text(category) },
+                            onClick = {
+                              onCategoryChange(category)
+                              onExpandChange(false)
+                            })
+                      }
+                    }
+              }
+            }
+
+        // New Interest Input
+        Card(
+            modifier = Modifier.weight(1f).testTag("TextFieldWithErrorStateCard"),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
+              OutlinedTextField(
+                  value = newInterest,
+                  onValueChange = { onInterestChange(it) },
+                  label = { Text("New Interest") },
+                  enabled = selectedCategory.isNotEmpty() && selectedCategory != "None",
+                  modifier = Modifier.testTag("newInterestInput"),
+                  colors =
+                      TextFieldDefaults.colors(
+                          unfocusedContainerColor = Color.Transparent,
+                          focusedContainerColor = Color.Transparent,
+                          focusedIndicatorColor = Color.Transparent,
+                          unfocusedIndicatorColor = Color.Transparent,
+                          errorIndicatorColor = Color.Transparent,
+                          errorContainerColor = Color.Transparent,
+                          disabledContainerColor = Color.Transparent,
+                          disabledIndicatorColor = Color.Transparent,
+                      ),
+                  singleLine = true)
+            }
       }
 }
 
 @Composable
-fun InterestEditBox(interest: String, onRemove: () -> Unit) {
+fun InterestEditBox(category: String, interest: String, onRemove: () -> Unit) {
+  val backgroundColor = InterestCategoriesColors[category] ?: Color.LightGray
+  Log.d("InterestEditBox", "Interest: $interest")
+  Log.d("InterestEditBox", "Category: $category")
+  Log.d("InterestEditBox", "Color: $backgroundColor")
+
   Box(
       modifier =
-          Modifier.background(Color.LightGray, RoundedCornerShape(STANDARD_PADDING.dp))
+          Modifier.background(color = backgroundColor, RoundedCornerShape(STANDARD_PADDING.dp))
               .padding(horizontal = MEDIUM_PADDING.dp, vertical = STANDARD_PADDING.dp)
               .testTag("$interest")) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -62,6 +61,7 @@ import com.android.sample.model.profile.User
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
+import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.SUBTITLE_FONTSIZE
 import com.android.sample.ui.camera.CameraScreen
@@ -292,27 +292,6 @@ fun ManageInterests(initialInterests: List<Interest>, onUpdateInterests: (List<I
             onInterestChange = { newInterest = it })
         Spacer(Modifier.height(STANDARD_PADDING.dp))
         // Add Button
-
-        // Interests List
-        LazyRow(
-            modifier = Modifier.testTag("interestsList"),
-            horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
-              items(newListInterests.size) { interest ->
-                InterestEditBox(
-                    category = newListInterests[interest].category,
-                    interest = newListInterests[interest].interest,
-                    onRemove = {
-                      performOfflineAwareAction(
-                          context = context,
-                          networkManager = networkManager,
-                          onPerform = {
-                            val updatedList = newListInterests - newListInterests[interest]
-                            newListInterests = updatedList
-                            onUpdateInterests(updatedList)
-                          })
-                    })
-              }
-            }
         Button(
             onClick = {
               performOfflineAwareAction(
@@ -337,6 +316,26 @@ fun ManageInterests(initialInterests: List<Interest>, onUpdateInterests: (List<I
             modifier = Modifier.testTag("addInterestButton"),
             shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
               Text("Add Interest")
+            }
+        // Interests List
+        LazyRow(
+            modifier = Modifier.testTag("interestsList"),
+            horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
+              items(newListInterests.size) { interest ->
+                InterestEditBox(
+                    category = newListInterests[interest].category,
+                    interest = newListInterests[interest].interest,
+                    onRemove = {
+                      performOfflineAwareAction(
+                          context = context,
+                          networkManager = networkManager,
+                          onPerform = {
+                            val updatedList = newListInterests - newListInterests[interest]
+                            newListInterests = updatedList
+                            onUpdateInterests(updatedList)
+                          })
+                    })
+              }
             }
       }
 }
@@ -422,21 +421,38 @@ fun InterestInputRow(
 @Composable
 fun InterestEditBox(category: String, interest: String, onRemove: () -> Unit) {
   val backgroundColor = InterestCategoriesColors[category] ?: Color.LightGray
-  Log.d("InterestEditBox", "Interest: $interest")
-  Log.d("InterestEditBox", "Category: $category")
-  Log.d("InterestEditBox", "Color: $backgroundColor")
 
   Box(
       modifier =
-          Modifier.background(color = backgroundColor, RoundedCornerShape(STANDARD_PADDING.dp))
-              .padding(horizontal = MEDIUM_PADDING.dp, vertical = STANDARD_PADDING.dp)
-              .testTag("$interest")) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Text(text = interest, fontSize = SUBTITLE_FONTSIZE.sp, color = Color.Black)
-          Spacer(Modifier.width(STANDARD_PADDING.dp))
-          IconButton(onClick = onRemove, modifier = Modifier.testTag("removeInterest-$interest")) {
-            Icon(imageVector = Icons.Default.Close, contentDescription = "Remove")
-          }
-        }
+          Modifier.background(
+                  color = backgroundColor,
+                  shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp))
+              .padding(horizontal = MEDIUM_PADDING.dp)
+              .testTag("$interest"),
+      contentAlignment = Alignment.Center // Ensures content is centered within the Box
+      ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement =
+                Arrangement.SpaceBetween, // Ensures spacing between Text and Icon
+            modifier = Modifier.fillMaxWidth() // Allows Row to take full width of the Box
+            ) {
+              Text(
+                  text = interest,
+                  fontSize = SUBTITLE_FONTSIZE.sp,
+                  color = Color.Black,
+                  modifier =
+                      Modifier.padding(vertical = MEDIUM_PADDING.dp, horizontal = SMALL_PADDING.dp))
+              IconButton(
+                  onClick = onRemove,
+                  modifier =
+                      Modifier.size(18.dp) // Optional: Adjust size of the IconButton
+                          .testTag("removeInterest-$interest")) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Remove",
+                        modifier = Modifier.fillMaxSize())
+                  }
+            }
       }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.profile
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.camera.view.CameraController
@@ -165,17 +166,10 @@ fun EditProfileScreen(
                       isPictureRemoved = true // Mark picture for removal
                     })
 
-                Button(
-                    onClick = {
-                      performOfflineAwareAction(
-                          context = context,
-                          networkManager = networkManager,
-                          onPerform = { showDialogImage = true },
-                      )
-                    },
-                    modifier = Modifier.testTag("uploadPicture")) {
-                      Text("Modify Profile Picture")
-                    }
+                ModifyPictureButton(
+                    context = context,
+                    networkManager = networkManager,
+                    onPerformAction = { showDialogImage = true })
 
                 OutlinedTextField(
                     value = name,
@@ -456,5 +450,22 @@ fun InterestEditBox(category: String, interest: String, onRemove: () -> Unit) {
                         modifier = Modifier.fillMaxSize())
                   }
             }
+      }
+}
+
+@Composable
+fun ModifyPictureButton(
+    context: Context,
+    networkManager: NetworkManager,
+    onPerformAction: () -> Unit,
+    modifier: Modifier = Modifier.testTag("uploadPicture")
+) {
+  Button(
+      onClick = {
+        performOfflineAwareAction(
+            context = context, networkManager = networkManager, onPerform = onPerformAction)
+      },
+      modifier = modifier) {
+        Text("Modify Profile Picture")
       }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EditProfile.kt
@@ -58,12 +58,14 @@ import com.android.sample.model.profile.InterestCategories
 import com.android.sample.model.profile.InterestCategoriesColors
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
+import com.android.sample.resources.C.Tag.CARD_ELEVATION_DEFAULT
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.SUBTITLE_FONTSIZE
+import com.android.sample.resources.C.Tag.TEXT_FONTSIZE
 import com.android.sample.ui.camera.CameraScreen
 import com.android.sample.ui.camera.GalleryScreen
 import com.android.sample.ui.camera.ProfileImage
@@ -358,7 +360,7 @@ fun InterestInputRow(
         Card(
             modifier = Modifier.weight(1f).testTag("TextFieldWithErrorStateCard"),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION_DEFAULT.dp),
             shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
               ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = onExpandChange) {
                 OutlinedTextField(
@@ -394,7 +396,7 @@ fun InterestInputRow(
         Card(
             modifier = Modifier.weight(1f).testTag("TextFieldWithErrorStateCard"),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION_DEFAULT.dp),
             shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
               OutlinedTextField(
                   value = newInterest,
@@ -446,7 +448,7 @@ fun InterestEditBox(category: String, interest: String, onRemove: () -> Unit) {
               IconButton(
                   onClick = onRemove,
                   modifier =
-                      Modifier.size(18.dp) // Optional: Adjust size of the IconButton
+                      Modifier.size(TEXT_FONTSIZE.dp) // Optional: Adjust size of the IconButton
                           .testTag("removeInterest-$interest")) {
                     Icon(
                         imageVector = Icons.Default.Close,

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
@@ -4,7 +4,10 @@ import android.graphics.Bitmap
 import android.util.Log
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,8 +21,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,7 +37,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.model.image.ImageViewModel
@@ -46,7 +50,9 @@ import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
+import com.android.sample.resources.C.Tag.SUBTITLE_FONTSIZE
 import com.android.sample.resources.C.Tag.TITLE_FONTSIZE
+import com.android.sample.resources.C.Tag.WIDTH_FRACTION_MD
 import com.android.sample.ui.camera.CameraScreen
 import com.android.sample.ui.camera.GalleryScreen
 import com.android.sample.ui.camera.ProfileImage
@@ -56,7 +62,6 @@ import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.auth.FirebaseAuth
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileCreationScreen(
     viewModel: ProfileViewModel,
@@ -139,21 +144,29 @@ fun ProfileCreationScreen(
           Text(
               text = "Complete your profile creation",
               fontSize = TITLE_FONTSIZE.sp,
-              fontWeight = FontWeight.Bold, // Set the text to be bold
               modifier =
                   Modifier.padding(MEDIUM_PADDING.dp)
                       .wrapContentWidth(Alignment.CenterHorizontally)
                       .testTag("profileCreationTitle"))
-
+          Spacer(modifier = Modifier.padding(MEDIUM_PADDING.dp))
           ProfileImage(
               userId = uid,
-              modifier = Modifier.size(IMAGE_SIZE.dp).clip(CircleShape).testTag("profilePicture"),
+              modifier =
+                  Modifier.size((1.5 * IMAGE_SIZE).dp).clip(CircleShape).testTag("profilePicture"),
               imageViewModel)
 
-          Button(
-              onClick = { showDialogImage = true }, modifier = Modifier.testTag("uploadPicture")) {
-                Text("Modify Profile Picture")
+          Box(
+              modifier =
+                  Modifier.testTag("uploadPicture")
+                      .clickable { showDialogImage = true } // Handle click action
+                      .padding(MEDIUM_PADDING.dp)
+                      .background(Color.Transparent)) {
+                Icon(
+                    imageVector = Icons.Default.AddAPhoto,
+                    contentDescription = "Add a photo",
+                    tint = Color.Black)
               }
+
           Spacer(modifier = Modifier.padding((2 * LARGE_PADDING).dp))
 
           Row(
@@ -228,10 +241,10 @@ fun ProfileCreationScreen(
               },
               modifier =
                   Modifier.testTag("createProfileButton")
-                      .fillMaxWidth()
+                      .fillMaxWidth(WIDTH_FRACTION_MD)
                       .height(AUTH_BUTTON_HEIGHT.dp),
               shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
-                Text("Create Profile")
+                Text("Create Profile", fontSize = SUBTITLE_FONTSIZE.sp)
               }
 
           errorMessage?.let {

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
@@ -24,7 +24,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,6 +47,7 @@ import com.android.sample.model.profile.Interest
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
 import com.android.sample.resources.C.Tag.AUTH_BUTTON_HEIGHT
+import com.android.sample.resources.C.Tag.CARD_ELEVATION_DEFAULT
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
 import com.android.sample.resources.C.Tag.LARGE_PADDING
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
@@ -202,49 +206,58 @@ fun ProfileCreationScreen(
               initialInterests = interests, onUpdateInterests = { newListInterests = it })
 
           Spacer(modifier = Modifier.padding(STANDARD_PADDING.dp))
-          Button(
-              onClick = {
-                // Set errors if fields are empty
-                nameErrorState.value = if (name.isBlank()) "Name cannot be empty" else null
-                surnameErrorState.value = if (surname.isBlank()) "Surname cannot be empty" else null
-
-                // Proceed only if there are no errors
-                if (nameErrorState.value == null && surnameErrorState.value == null) {
-                  selectedBitmap?.let { bitmap ->
-                    imageViewModel.uploadProfilePicture(
-                        uid,
-                        bitmap,
-                        onSuccess = { url ->
-                          photo = url // Update photo URL in profile
-                        },
-                        onFailure = { error -> errorMessage = error.message })
-                  }
-                  val userProfile =
-                      User(
-                          id = uid,
-                          name = name,
-                          surname = surname,
-                          interests = newListInterests,
-                          activities = emptyList(),
-                          photo = photo,
-                          likedActivities = emptyList())
-
-                  viewModel.createUserProfile(
-                      userProfile = userProfile,
-                      onSuccess = {
-                        Log.d("ProfileCreation", "Profile created successfully")
-                        viewModel.fetchUserData(uid)
-                        navigationActions.navigateTo(Screen.OVERVIEW)
-                      },
-                      onError = { error -> errorMessage = error.message })
-                }
-              },
+          Card(
               modifier =
-                  Modifier.testTag("createProfileButton")
-                      .fillMaxWidth(WIDTH_FRACTION_MD)
-                      .height(AUTH_BUTTON_HEIGHT.dp),
+                  Modifier.fillMaxWidth(WIDTH_FRACTION_MD).testTag("ProfileCreationButtonCard"),
+              colors =
+                  CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+              elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION_DEFAULT.dp),
               shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
-                Text("Create Profile", fontSize = SUBTITLE_FONTSIZE.sp)
+                Button(
+                    onClick = {
+                      // Set errors if fields are empty
+                      nameErrorState.value = if (name.isBlank()) "Name cannot be empty" else null
+                      surnameErrorState.value =
+                          if (surname.isBlank()) "Surname cannot be empty" else null
+
+                      // Proceed only if there are no errors
+                      if (nameErrorState.value == null && surnameErrorState.value == null) {
+                        selectedBitmap?.let { bitmap ->
+                          imageViewModel.uploadProfilePicture(
+                              uid,
+                              bitmap,
+                              onSuccess = { url ->
+                                photo = url // Update photo URL in profile
+                              },
+                              onFailure = { error -> errorMessage = error.message })
+                        }
+                        val userProfile =
+                            User(
+                                id = uid,
+                                name = name,
+                                surname = surname,
+                                interests = newListInterests,
+                                activities = emptyList(),
+                                photo = photo,
+                                likedActivities = emptyList())
+
+                        viewModel.createUserProfile(
+                            userProfile = userProfile,
+                            onSuccess = {
+                              Log.d("ProfileCreation", "Profile created successfully")
+                              viewModel.fetchUserData(uid)
+                              navigationActions.navigateTo(Screen.OVERVIEW)
+                            },
+                            onError = { error -> errorMessage = error.message })
+                      }
+                    },
+                    modifier =
+                        Modifier.testTag("createProfileButton")
+                            .fillMaxWidth()
+                            .height(AUTH_BUTTON_HEIGHT.dp),
+                    shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
+                      Text("Create Profile", fontSize = SUBTITLE_FONTSIZE.sp)
+                    }
               }
 
           errorMessage?.let {

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileCreation.kt
@@ -7,13 +7,16 @@ import androidx.camera.view.LifecycleCameraController
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -36,9 +39,11 @@ import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.profile.Interest
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.User
+import com.android.sample.resources.C.Tag.AUTH_BUTTON_HEIGHT
 import com.android.sample.resources.C.Tag.IMAGE_SIZE
 import com.android.sample.resources.C.Tag.LARGE_PADDING
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
+import com.android.sample.resources.C.Tag.ROUNDED_CORNER_SHAPE_DEFAULT
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.TITLE_FONTSIZE
@@ -125,7 +130,7 @@ fun ProfileCreationScreen(
   } else {
     Column(
         modifier =
-            Modifier.fillMaxSize()
+            Modifier.fillMaxWidth()
                 .padding(MEDIUM_PADDING.dp)
                 .verticalScroll(scrollState)
                 .testTag("profileCreationScrollColumn"),
@@ -151,24 +156,31 @@ fun ProfileCreationScreen(
               }
           Spacer(modifier = Modifier.padding((2 * LARGE_PADDING).dp))
 
-          TextFieldWithErrorState(
-              value = name,
-              onValueChange = { name = it },
-              label = "Name",
-              validation = { input -> if (input.isBlank()) "Name cannot be empty" else null },
-              externalError = nameErrorState.value,
-              modifier = Modifier.testTag("nameTextField"),
-              errorTestTag = "nameError")
+          Row(
+              Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp)) {
+                TextFieldWithErrorState(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = "Name",
+                    validation = { input -> if (input.isBlank()) "Name cannot be empty" else null },
+                    externalError = nameErrorState.value,
+                    modifier = Modifier.weight(1f),
+                    errorTestTag = "nameError",
+                    testTag = "nameTextField")
+                TextFieldWithErrorState(
+                    value = surname,
+                    onValueChange = { surname = it },
+                    label = "Surname",
+                    validation = { input ->
+                      if (input.isBlank()) "Surname cannot be empty" else null
+                    },
+                    externalError = surnameErrorState.value,
+                    modifier = Modifier.weight(1f),
+                    errorTestTag = "surnameError",
+                    testTag = "surnameTextField")
+              }
 
-          Spacer(modifier = Modifier.padding(STANDARD_PADDING.dp))
-          TextFieldWithErrorState(
-              value = surname,
-              onValueChange = { surname = it },
-              label = "Surname",
-              validation = { input -> if (input.isBlank()) "Surname cannot be empty" else null },
-              externalError = surnameErrorState.value,
-              modifier = Modifier.testTag("surnameTextField"),
-              errorTestTag = "surnameError")
           Spacer(modifier = Modifier.padding(STANDARD_PADDING.dp))
 
           var newListInterests by remember { mutableStateOf(interests) }
@@ -214,7 +226,11 @@ fun ProfileCreationScreen(
                       onError = { error -> errorMessage = error.message })
                 }
               },
-              modifier = Modifier.testTag("createProfileButton")) {
+              modifier =
+                  Modifier.testTag("createProfileButton")
+                      .fillMaxWidth()
+                      .height(AUTH_BUTTON_HEIGHT.dp),
+              shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp)) {
                 Text("Create Profile")
               }
 


### PR DESCRIPTION
Fixes #338
In this PR, none of the business logic was touched, but IO refactored a lot of UI:
- I added colors for interest categories
- I displayed colors for each interest in profile creation
- I adjusted the UI of the Profile reation Screen to display name and surname in one row
- I added textures to all the textfields thanks to the card
### Important:
### - Here is the UI we should all follow for our ui elements (text fields, buttons etc.):
```kotlin
            Card(
                modifier = Modifier.fillMaxWidth(WIDTH_FRACTION_SM).testTag("PurposeCard"),
                colors =
                    CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
                elevation =
                    CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION_DEFAULT.dp),
                shape = RoundedCornerShape(ROUNDED_CORNER_SHAPE_DEFAULT.dp),
            ) {
                  OutlinedButton() // or textField etc...
                  }
``` 
Here you can see the changes added: 
![image](https://github.com/user-attachments/assets/a3d75600-b2fa-4e4f-a764-a5a5ec489ff1)
