### PR TITLE
Remove "more..." button in the location query

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -401,13 +401,6 @@ fun CreateActivityScreen(
                             },
                             modifier = Modifier.padding(STANDARD_PADDING.dp))
                       }
-
-                      if (locationSuggestions.size > 3) {
-                        DropdownMenuItem(
-                            text = { Text("More...") },
-                            onClick = {},
-                            modifier = Modifier.padding(STANDARD_PADDING.dp))
-                      }
                     }
               }
               Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -504,13 +504,6 @@ fun EditActivityScreen(
                           },
                           modifier = Modifier.padding(STANDARD_PADDING.dp))
                     }
-
-                    if (locationSuggestions.size > 3) {
-                      DropdownMenuItem(
-                          text = { Text("More...") },
-                          onClick = { /* TODO: Define behavior for 'More...' */},
-                          modifier = Modifier.padding(STANDARD_PADDING.dp))
-                    }
                   }
             }
 


### PR DESCRIPTION
In this PR, I decided (after discussions with you) to remove the more... button as the first idea was to make it show 6 locations instead of 3, but it was very heavy for the app and made a lot of bugs, so removing it is not a big deal, because when being precise enough we can always find the location we are looking for