### PR TITLE
Remove "choose-account-screen" appearing for a small amount of time

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/components/LoadingScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/components/LoadingScreenTest.kt
@@ -6,13 +6,13 @@ import androidx.compose.ui.test.onNodeWithText
 import org.junit.Rule
 import org.junit.Test
 
-class NoInternetScreenTest {
+class LoadingScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun NoInternetScreen_displaysCorrectTexts() {
-    composeTestRule.setContent { NoInternetScreen() }
+  fun loadingScreen_displaysCorrectText() {
+    composeTestRule.setContent { LoadingScreen("No internet connection") }
 
     // Directly use the hardcoded expected string for the assertion
     composeTestRule.onNodeWithText("No internet connection").assertIsDisplayed()

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -66,7 +66,7 @@ import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.ui.camera.CameraScreen
 import com.android.sample.ui.camera.GalleryScreen
-import com.android.sample.ui.components.NoInternetScreen
+import com.android.sample.ui.components.LoadingScreen
 import com.android.sample.ui.dialogs.AddImageDialog
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -141,7 +141,7 @@ fun CreateActivityScreen(
       },
       content = { paddingValues ->
         if (!networkManager.isNetworkAvailable()) {
-          NoInternetScreen()
+          LoadingScreen(stringResource(id = R.string.no_internet_connection))
         } else {
           if (isCamOpen) {
             CameraScreen(

--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -45,6 +45,7 @@ import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.SUBTITLE_FONTSIZE
 import com.android.sample.resources.C.Tag.TITLE_FONTSIZE
 import com.android.sample.resources.C.Tag.WIDTH_FRACTION_SM
+import com.android.sample.ui.components.LoadingScreen
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
 
@@ -57,8 +58,20 @@ fun ChooseAccountScreen(
 ) {
   // Collect the user profile data from ProfileViewModel
   val userProfile by profileViewModel.userState.collectAsState()
+    val isLoading = userProfile == null // Assume loading state when userProfile is null
+    if (isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            LoadingScreen()
+        }
+        return
+    }
+
   if (userProfile != null) {
     navigationActions.navigateTo(Screen.OVERVIEW)
+      return
   }
   val continueMessage = stringResource(R.string.complete_profile_creation_message)
 

--- a/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/ChooseAccount.kt
@@ -58,20 +58,15 @@ fun ChooseAccountScreen(
 ) {
   // Collect the user profile data from ProfileViewModel
   val userProfile by profileViewModel.userState.collectAsState()
-    val isLoading = userProfile == null // Assume loading state when userProfile is null
-    if (isLoading) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            LoadingScreen()
-        }
-        return
-    }
+  val isLoading = userProfile == null // Assume loading state when userProfile is null
+  if (isLoading) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { LoadingScreen() }
+    return
+  }
 
   if (userProfile != null) {
     navigationActions.navigateTo(Screen.OVERVIEW)
-      return
+    return
   }
   val continueMessage = stringResource(R.string.complete_profile_creation_message)
 

--- a/app/src/main/java/com/android/sample/ui/components/LoadingScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/components/LoadingScreen.kt
@@ -25,7 +25,7 @@ import com.android.sample.resources.C.Tag.SPINNING_DURATION
 import com.android.sample.resources.C.Tag.TITLE_FONTSIZE
 
 @Composable
-fun NoInternetScreen() {
+fun LoadingScreen(message: String = "") {
   Box(
       modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
       contentAlignment = Alignment.Center) {
@@ -64,7 +64,7 @@ fun NoInternetScreen() {
                   modifier = Modifier.size((2 * IMAGE_SIZE).dp).graphicsLayer(rotationZ = rotation))
               Spacer(modifier = Modifier.height(LARGE_PADDING.dp))
               Text(
-                  text = stringResource(R.string.no_internet_connection),
+                  text = message,
                   style =
                       TextStyle(
                           fontSize = TITLE_FONTSIZE.sp,

--- a/app/src/main/java/com/android/sample/ui/components/LoadingScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/components/LoadingScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.android.sample.R
@@ -55,7 +56,7 @@ import com.android.sample.resources.C.Tag.LARGE_IMAGE_SIZE
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
 import com.android.sample.resources.C.Tag.TEXT_FONTSIZE
-import com.android.sample.ui.components.NoInternetScreen
+import com.android.sample.ui.components.LoadingScreen
 import com.android.sample.ui.dialogs.FilterDialog
 import com.android.sample.ui.navigation.BottomNavigationMenu
 import com.android.sample.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -143,7 +144,7 @@ fun MapScreen(
       },
       content = { padding ->
         if (!networkManager.isNetworkAvailable()) {
-          NoInternetScreen()
+          LoadingScreen(message = stringResource(R.string.no_internet_connection))
         } else {
           Box(modifier = Modifier.fillMaxSize()) {
             GoogleMap(


### PR DESCRIPTION
In this PR, I handled the problem of the "choose-account" screen appearing quickly when opening the app, this was due to the fact that we navigate to the Overview screen once te profile is fetched, and this time to fetch the profile was causing the screen to appear.
The solution was to put a loading screen while we are fetching the profile.