### PR TITLE
Refactor: createActivity and editActivity for inconsistencies

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
@@ -265,7 +265,7 @@ fun ActivityForm(
         when {
           price.isEmpty() -> context.getString(R.string.price_empty)
           price.toDoubleOrNull() == null -> context.getString(R.string.price_nan)
-            price.toDouble() < 0 -> context.getString(R.string.price_neg)
+          price.toDouble() < 0 -> context.getString(R.string.price_neg)
           else -> null
         }
       },
@@ -280,7 +280,8 @@ fun ActivityForm(
       validation = { placesMax ->
         when {
           placesMax.isEmpty() -> context.getString(R.string.places_empty)
-          placesMax.toIntOrNull() == null -> context.getString(R.string.places_nan)
+          placesMax.toLongOrNull() == null -> context.getString(R.string.places_nan)
+          price.toLong() <= 0 -> context.getString(R.string.places_neg)
           else -> null
         }
       },

--- a/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
@@ -264,7 +264,8 @@ fun ActivityForm(
       validation = { price ->
         when {
           price.isEmpty() -> context.getString(R.string.price_empty)
-          price.toIntOrNull() == null -> context.getString(R.string.price_nan)
+          price.toDoubleOrNull() == null -> context.getString(R.string.price_nan)
+            price.toDouble() < 0 -> context.getString(R.string.price_neg)
           else -> null
         }
       },

--- a/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
@@ -280,8 +280,8 @@ fun ActivityForm(
       validation = { placesMax ->
         when {
           placesMax.isEmpty() -> context.getString(R.string.places_empty)
-          placesMax.toLongOrNull() == null -> context.getString(R.string.places_nan)
-          price.toLong() <= 0 -> context.getString(R.string.places_neg)
+          placesMax.toIntOrNull() == null -> context.getString(R.string.places_nan)
+          placesMax.toInt() <= 0 -> context.getString(R.string.places_neg)
           else -> null
         }
       },

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -332,14 +332,18 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (price.isNotBlank()  || price.toDoubleOrNull() == null || price.toDouble() < 0) {
+                    } else if (price.isNotBlank() ||
+                        price.toDoubleOrNull() == null ||
+                        price.toDouble() < 0) {
                       Toast.makeText(
                               context,
                               context.getString(R.string.invalid_price_format),
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if ( placesMax.isNotBlank() || placesMax.toLongOrNull() == null ||  placesMax.toLong() <= 0) {
+                    } else if (placesMax.isNotBlank() ||
+                        placesMax.toLongOrNull() == null ||
+                        placesMax.toLong() <= 0) {
                       Toast.makeText(
                               context,
                               context.getString(R.string.invalid_places_format),
@@ -347,12 +351,12 @@ fun CreateActivityScreen(
                           .show()
                       return@Button
                     } else if (attendees.size >= placesMax.toLong()) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.max_places_exceed),
-                            Toast.LENGTH_SHORT)
-                            .show()
-                        return@Button
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.max_places_exceed),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      return@Button
                     } else if (selectedLocation == null) {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -332,7 +332,7 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (price.isNotBlank() ||
+                    } else if (price.isBlank() ||
                         price.toDoubleOrNull() == null ||
                         price.toDouble() < 0) {
                       Toast.makeText(
@@ -341,7 +341,7 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (placesMax.isNotBlank() ||
+                    } else if (placesMax.isBlank() ||
                         placesMax.toLongOrNull() == null ||
                         placesMax.toLong() <= 0) {
                       Toast.makeText(

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -339,13 +339,6 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (!hourDateViewModel.isBeginGreaterThanEnd(startTime, duration)) {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.startTime_before_endTime),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      return@Button
                     } else if (price.toDoubleOrNull() == null) {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/CreateActivity.kt
@@ -325,13 +325,6 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (attendees.size >= placesMax.toInt()) {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.max_places_exceed),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      return@Button
                     } else if (creator == "") {
                       Toast.makeText(
                               context,
@@ -339,20 +332,27 @@ fun CreateActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (price.toDoubleOrNull() == null) {
+                    } else if (price.isNotBlank()  || price.toDoubleOrNull() == null || price.toDouble() < 0) {
                       Toast.makeText(
                               context,
                               context.getString(R.string.invalid_price_format),
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (placesMax.toLongOrNull() == null) {
+                    } else if ( placesMax.isNotBlank() || placesMax.toLongOrNull() == null ||  placesMax.toLong() <= 0) {
                       Toast.makeText(
                               context,
                               context.getString(R.string.invalid_places_format),
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
+                    } else if (attendees.size >= placesMax.toLong()) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.max_places_exceed),
+                            Toast.LENGTH_SHORT)
+                            .show()
+                        return@Button
                     } else if (selectedLocation == null) {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -330,6 +330,20 @@ fun EditActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
+                    } else if (price.toDoubleOrNull() == null) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.invalid_price_format),
+                            Toast.LENGTH_SHORT)
+                            .show()
+                        return@Button
+                    } else if (maxPlaces.toLongOrNull() == null) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.invalid_places_format),
+                            Toast.LENGTH_SHORT)
+                            .show()
+                        return@Button
                     } else if (selectedOptionCategory != null &&
                         selectedOptionCategory != categoryOf[selectedOptionInterest]) {
                       Toast.makeText(

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -322,25 +322,24 @@ fun EditActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                      // we force the start time to be before the end time
-                    } else if (attendees.size >= maxPlaces.toInt()) {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.max_places_exceed),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      return@Button
-                    } else if (price.toDoubleOrNull() == null) {
+                    } else if ( price.isBlank() || price.toDoubleOrNull() == null || price.toDouble() < 0) {
                         Toast.makeText(
                             context,
                             context.getString(R.string.invalid_price_format),
                             Toast.LENGTH_SHORT)
                             .show()
                         return@Button
-                    } else if (maxPlaces.toLongOrNull() == null) {
+                    } else if ( maxPlaces.isBlank() || maxPlaces.toLongOrNull() == null ||  maxPlaces.toLong() <= 0) {
                         Toast.makeText(
                             context,
                             context.getString(R.string.invalid_places_format),
+                            Toast.LENGTH_SHORT)
+                            .show()
+                        return@Button
+                    } else if (attendees.size >= maxPlaces.toLong()) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.max_places_exceed),
                             Toast.LENGTH_SHORT)
                             .show()
                         return@Button

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -330,14 +330,6 @@ fun EditActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if (!hourDateViewModel.isBeginGreaterThanEnd(
-                        startTime ?: "00:00", duration ?: "00:01")) {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.startTime_before_endTime),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      return@Button
                     } else if (selectedOptionCategory != null &&
                         selectedOptionCategory != categoryOf[selectedOptionInterest]) {
                       Toast.makeText(

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -322,27 +322,31 @@ fun EditActivityScreen(
                               Toast.LENGTH_SHORT)
                           .show()
                       return@Button
-                    } else if ( price.isBlank() || price.toDoubleOrNull() == null || price.toDouble() < 0) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.invalid_price_format),
-                            Toast.LENGTH_SHORT)
-                            .show()
-                        return@Button
-                    } else if ( maxPlaces.isBlank() || maxPlaces.toLongOrNull() == null ||  maxPlaces.toLong() <= 0) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.invalid_places_format),
-                            Toast.LENGTH_SHORT)
-                            .show()
-                        return@Button
+                    } else if (price.isBlank() ||
+                        price.toDoubleOrNull() == null ||
+                        price.toDouble() < 0) {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.invalid_price_format),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      return@Button
+                    } else if (maxPlaces.isBlank() ||
+                        maxPlaces.toLongOrNull() == null ||
+                        maxPlaces.toLong() <= 0) {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.invalid_places_format),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      return@Button
                     } else if (attendees.size >= maxPlaces.toLong()) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.max_places_exceed),
-                            Toast.LENGTH_SHORT)
-                            .show()
-                        return@Button
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.max_places_exceed),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      return@Button
                     } else if (selectedOptionCategory != null &&
                         selectedOptionCategory != categoryOf[selectedOptionInterest]) {
                       Toast.makeText(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="price_empty">Price must not be empty</string>
     <string name="price_nan">Price must be a number</string>
     <string name="places_empty">Places must not be empty</string>
-    <string name="places_nan">Places must be a number</string>
+    <string name="places_nan">Places must be an integer number</string>
     <string name="location_empty">Location must not be empty</string>
-
+    
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,5 +56,6 @@
     <string name="places_empty">Places must not be empty</string>
     <string name="places_nan">Places must be an integer number</string>
     <string name="location_empty">Location must not be empty</string>
-    
+    <string name="price_neg">Price must not be negative</string>
+    <string name="places_neg">Places must not be negative</string>
 </resources>


### PR DESCRIPTION
In this PR, I fix the inconsistencies we had in edit and create activity. For example, we could give a number of participants of zero or put strings instead if numbers for max number of places and price fields.

I also solved an issue about "start time must be before end time" toast that was still displaying even though we changed "end time" variable by "duration" now. 

Now, we check entered value:
- is not negative (can be 0 for the price, not for maxPlaces)
- is a number only, no characters (can be double for price and is int for maxPlaces)
- is not empty

closes #336 
