### PR TITLE
Refactor/replace icons by text in profile

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -18,9 +18,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material.icons.filled.ThumbUp
-import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.Groups
-import androidx.compose.material.icons.outlined.HourglassFull
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -64,7 +61,6 @@ import com.android.sample.resources.C.Tag.MAXIMUM_FONT_WEIGHT
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.NORMAL_PADDING
 import com.android.sample.resources.C.Tag.PAST_ACTIVITIES
-import com.android.sample.resources.C.Tag.PRIMARY
 import com.android.sample.resources.C.Tag.ROW_WIDTH
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
@@ -457,35 +453,69 @@ fun UserProfile(
                   horizontalArrangement = Arrangement.SpaceEvenly,
                   verticalAlignment = Alignment.Top,
                   modifier = Modifier.fillMaxWidth().testTag("activityTypeRow")) {
+                    Text(
+                        "Created",
+                        modifier =
+                            Modifier.testTag("createdActivities").clickable {
+                              activityType = CREATED_ACTIVITIES
+                            },
+                        style =
+                            if (activityType == CREATED_ACTIVITIES) {
+                              TextStyle(
+                                  textDecoration =
+                                      TextDecoration.Underline // Applique le soulignement
+                                  )
+                            } else TextStyle(),
+                        color =
+                            if (activityType == CREATED_ACTIVITIES) Color(MAIN_COLOR_DARK)
+                            else Color.Gray,
+                        fontWeight =
+                            if (activityType == CREATED_ACTIVITIES) FontWeight.Bold
+                            else FontWeight.Normal,
+                    )
 
-                          Text( "Created", modifier=
-                                  Modifier.testTag("createdActivities").clickable {  activityType = CREATED_ACTIVITIES},
-                              style=if(activityType== CREATED_ACTIVITIES){ TextStyle(
-                                  textDecoration = TextDecoration.Underline // Applique le soulignement
-                              )} else TextStyle(),
-                              color=if(activityType== CREATED_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
-                              fontWeight = if(activityType==CREATED_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)
+                    Text(
+                        "Enrolled",
+                        modifier =
+                            Modifier.testTag("enrolledActivities").clickable {
+                              activityType = ENROLLED_ACTIVITIES
+                            },
+                        style =
+                            if (activityType == ENROLLED_ACTIVITIES) {
+                              TextStyle(
+                                  textDecoration =
+                                      TextDecoration.Underline // Applique le soulignement
+                                  )
+                            } else TextStyle(),
+                        color =
+                            if (activityType == ENROLLED_ACTIVITIES) Color(MAIN_COLOR_DARK)
+                            else Color.Gray,
+                        fontWeight =
+                            if (activityType == ENROLLED_ACTIVITIES) FontWeight.Bold
+                            else FontWeight.Normal,
+                    )
 
-
-
-
-                  Text( "Enrolled", modifier=
-                  Modifier.testTag("enrolledActivities").clickable {  activityType = ENROLLED_ACTIVITIES},
-                        style=if(activityType== ENROLLED_ACTIVITIES){ TextStyle(
-                            textDecoration = TextDecoration.Underline // Applique le soulignement
-                        )} else TextStyle(),
-                      color=if(activityType== ENROLLED_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
-                      fontWeight = if(activityType== ENROLLED_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)
-
-
-
-            Text( "Passed", modifier=
-            Modifier.testTag("passedActivities").clickable {  activityType = PAST_ACTIVITIES},
-                style=if(activityType== PAST_ACTIVITIES){ TextStyle(
-                    textDecoration = TextDecoration.Underline // Applique le soulignement
-                )} else TextStyle(),
-                color=if(activityType== PAST_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
-                fontWeight = if(activityType== PAST_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)}
+                    Text(
+                        "Passed",
+                        modifier =
+                            Modifier.testTag("passedActivities").clickable {
+                              activityType = PAST_ACTIVITIES
+                            },
+                        style =
+                            if (activityType == PAST_ACTIVITIES) {
+                              TextStyle(
+                                  textDecoration =
+                                      TextDecoration.Underline // Applique le soulignement
+                                  )
+                            } else TextStyle(),
+                        color =
+                            if (activityType == PAST_ACTIVITIES) Color(MAIN_COLOR_DARK)
+                            else Color.Gray,
+                        fontWeight =
+                            if (activityType == PAST_ACTIVITIES) FontWeight.Bold
+                            else FontWeight.Normal,
+                    )
+                  }
 
               Column(
                   verticalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp, Alignment.Top),

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -58,10 +59,12 @@ import com.android.sample.resources.C.Tag.IMAGE_SIZE
 import com.android.sample.resources.C.Tag.LARGE_FONT_WEIGHT
 import com.android.sample.resources.C.Tag.LARGE_PADDING
 import com.android.sample.resources.C.Tag.LIGHT_PURPLE_COLOR
+import com.android.sample.resources.C.Tag.MAIN_COLOR_DARK
 import com.android.sample.resources.C.Tag.MAXIMUM_FONT_WEIGHT
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.NORMAL_PADDING
 import com.android.sample.resources.C.Tag.PAST_ACTIVITIES
+import com.android.sample.resources.C.Tag.PRIMARY
 import com.android.sample.resources.C.Tag.ROW_WIDTH
 import com.android.sample.resources.C.Tag.SMALL_PADDING
 import com.android.sample.resources.C.Tag.STANDARD_PADDING
@@ -454,35 +457,36 @@ fun UserProfile(
                   horizontalArrangement = Arrangement.SpaceEvenly,
                   verticalAlignment = Alignment.Top,
                   modifier = Modifier.fillMaxWidth().testTag("activityTypeRow")) {
-                    IconButton(
-                        onClick = { activityType = CREATED_ACTIVITIES },
-                        modifier =
-                            if (activityType == CREATED_ACTIVITIES)
-                                Modifier.background(Color.LightGray, shape = CircleShape)
-                                    .testTag("createdActivities")
-                            else Modifier.testTag("createdActivities")) {
-                          Icon(Icons.Outlined.Edit, contentDescription = "Created")
-                        }
 
-                    IconButton(
-                        onClick = { activityType = ENROLLED_ACTIVITIES },
-                        modifier =
-                            if (activityType == ENROLLED_ACTIVITIES)
-                                Modifier.background(Color.LightGray, shape = CircleShape)
-                                    .testTag("enrolledActivities")
-                            else Modifier.testTag("enrolledActivities")) {
-                          Icon(Icons.Outlined.Groups, contentDescription = "Enrolled")
-                        }
-                    IconButton(
-                        onClick = { activityType = PAST_ACTIVITIES },
-                        modifier =
-                            if (activityType == PAST_ACTIVITIES)
-                                Modifier.background(Color.LightGray, shape = CircleShape)
-                                    .testTag("passedActivities")
-                            else Modifier.testTag("passedActivities")) {
-                          Icon(Icons.Outlined.HourglassFull, contentDescription = "Passed")
-                        }
-                  }
+                          Text( "Created", modifier=
+                                  Modifier.testTag("createdActivities").clickable {  activityType = CREATED_ACTIVITIES},
+                              style=if(activityType== CREATED_ACTIVITIES){ TextStyle(
+                                  textDecoration = TextDecoration.Underline // Applique le soulignement
+                              )} else TextStyle(),
+                              color=if(activityType== CREATED_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
+                              fontWeight = if(activityType==CREATED_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)
+
+
+
+
+                  Text( "Enrolled", modifier=
+                  Modifier.testTag("enrolledActivities").clickable {  activityType = ENROLLED_ACTIVITIES},
+                        style=if(activityType== ENROLLED_ACTIVITIES){ TextStyle(
+                            textDecoration = TextDecoration.Underline // Applique le soulignement
+                        )} else TextStyle(),
+                      color=if(activityType== ENROLLED_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
+                      fontWeight = if(activityType== ENROLLED_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)
+
+
+
+            Text( "Passed", modifier=
+            Modifier.testTag("passedActivities").clickable {  activityType = PAST_ACTIVITIES},
+                style=if(activityType== PAST_ACTIVITIES){ TextStyle(
+                    textDecoration = TextDecoration.Underline // Applique le soulignement
+                )} else TextStyle(),
+                color=if(activityType== PAST_ACTIVITIES) Color(MAIN_COLOR_DARK) else Color.Gray,
+                fontWeight = if(activityType== PAST_ACTIVITIES) FontWeight.Bold else FontWeight.Normal,)}
+
               Column(
                   verticalArrangement = Arrangement.spacedBy(STANDARD_PADDING.dp, Alignment.Top),
                   horizontalAlignment = Alignment.Start,


### PR DESCRIPTION

### **Title:**  
`refactor(ui): Replace icons in profile screen with text`

---

### **Description:**  
**What was changed:**  
- Replaced the icons in the profile screen with text labels:  
  - **Created**  
  - **Enrolled**  
  - **Passed**

**Why:**  
- Previously, the icons were unclear, and users did not understand their meaning.  
- Replacing the icons with text improves clarity and enhances the user experience (UX).

---

### **Before and After:**  
**Before:**  
- Icons without clear context or explanation:
<img width="169" alt="image" src="https://github.com/user-attachments/assets/3c7bfffe-4cf7-4f72-afaf-977bcde7f720" />



**After:**  
- Text labels (`Created`, `Enrolled`, `Passed`) make it explicit and user-friendly.
<img width="156" alt="image" src="https://github.com/user-attachments/assets/b05bb04c-534d-4789-857a-16ae9d227c76" />

---



Let me know if further modifications or screenshots are needed! 🚀
Close #426
