### PR TITLE
fix(gallery dismiss)

### DIFF
--- a/app/src/main/java/com/android/sample/ui/camera/Gallery.kt
+++ b/app/src/main/java/com/android/sample/ui/camera/Gallery.kt
@@ -48,20 +48,22 @@ fun GalleryScreen(isGalleryOpen: () -> Unit, addImage: (Bitmap) -> Unit, context
   val launcher =
       rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri?
         ->
-        uri?.let {
-          val bitmap = uriToBitmap(it, context)
-          bitmap?.let { bmp ->
-            addImage(bmp)
-            isGalleryOpen()
+        if (uri != null) {
+          val bitmap = uriToBitmap(uri, context)
+          if (bitmap != null) {
+            addImage(bitmap)
+            isGalleryOpen() // Close the gallery view
           }
+        } else {
+          isGalleryOpen() // Close the gallery view if no image is selected
         }
       }
 
-  LaunchedEffect(key1 = true) { launcher.launch("image/*") }
+  // Relaunch the image picker whenever GalleryScreen is recomposed
+  // which should typically be controlled by the state in the parent view
   DisposableEffect(Unit) {
-    onDispose {
-      isGalleryOpen() // Ensure the screen closes even if no image is selected
-    }
+    launcher.launch("image/*")
+    onDispose {}
   }
 }
 


### PR DESCRIPTION
FIx this bug :
- When clicking on the button gallery in the add image dialog, if I dismissed, when I clicked again on the button gallery screen, nothing would appear, so it would not be possible to choose pictures. Now even after dismissing, I can choose pictures after.