### PR TITLE
Hide FAB in map that appeared even if offline

### DIFF
--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -117,47 +117,37 @@ fun MapScreen(
 
   Scaffold(
       floatingActionButton = {
-          if(networkManager.isNetworkAvailable()) {
-              Row(
-                  modifier = Modifier
-                      .fillMaxWidth()
-                      .padding(horizontal = MEDIUM_PADDING.dp),
-                  horizontalArrangement = Arrangement.SpaceBetween
-              ) {
-                  FloatingActionButton(
-                      modifier =
-                      Modifier
-                          .padding(horizontal = MEDIUM_PADDING.dp)
-                          .testTag("centerOnCurrentLocation"),
-                      onClick = {
-                          coroutineScope.launch {
-                              currentLocation?.let {
-                                  val locationLatLng = LatLng(it.latitude, it.longitude)
-                                  cameraPositionState.animate(
-                                      update = CameraUpdateFactory.newLatLngZoom(
-                                          locationLatLng,
-                                          15f
-                                      ),
-                                      durationMs = 800
-                                  )
-                              }
-                          }
-                      }) {
+        if (networkManager.isNetworkAvailable()) {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(horizontal = MEDIUM_PADDING.dp),
+              horizontalArrangement = Arrangement.SpaceBetween) {
+                FloatingActionButton(
+                    modifier =
+                        Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+                            .testTag("centerOnCurrentLocation"),
+                    onClick = {
+                      coroutineScope.launch {
+                        currentLocation?.let {
+                          val locationLatLng = LatLng(it.latitude, it.longitude)
+                          cameraPositionState.animate(
+                              update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
+                              durationMs = 800)
+                        }
+                      }
+                    }) {
                       Icon(
                           Icons.Default.MyLocation,
-                          contentDescription = "Center on current location"
-                      )
-                  }
-                  FloatingActionButton(
-                      modifier =
-                      Modifier
-                          .padding(horizontal = MEDIUM_PADDING.dp)
-                          .testTag("filterDialogButton"),
-                      onClick = { showFilterDialog = true }) {
+                          contentDescription = "Center on current location")
+                    }
+                FloatingActionButton(
+                    modifier =
+                        Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+                            .testTag("filterDialogButton"),
+                    onClick = { showFilterDialog = true }) {
                       Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
-                  }
+                    }
               }
-          }
+        }
       },
       content = { padding ->
         if (!networkManager.isNetworkAvailable()) {
@@ -165,10 +155,7 @@ fun MapScreen(
         } else {
           Box(modifier = Modifier.fillMaxSize()) {
             GoogleMap(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .testTag("mapScreen"),
+                modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
                 cameraPositionState = cameraPositionState,
                 properties =
                     MapProperties(
@@ -203,8 +190,9 @@ fun MapScreen(
                             false
                         else if (listActivitiesViewModel.onlyPRO && it.type != ActivityType.PRO)
                             false
-                        else it.location != null) && hourDateViewModel
-                            .combineDateAndTime(it.date, it.duration) > Timestamp.now()
+                        else it.location != null) &&
+                            hourDateViewModel.combineDateAndTime(it.date, it.duration) >
+                                Timestamp.now()
                       }
                       .forEach { item ->
                         Marker(
@@ -277,13 +265,9 @@ fun MapScreen(
     ModalBottomSheet(
         onDismissRequest = { showBottomSheet = false },
     ) {
-      Column(modifier = Modifier
-          .fillMaxWidth()
-          .padding(MEDIUM_PADDING.dp)) {
+      Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(STANDARD_PADDING.dp),
+            modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
@@ -305,10 +289,7 @@ fun MapScreen(
 
 @Composable
 fun DisplayActivity(activity: Activity) {
-  Column(modifier = Modifier
-      .fillMaxWidth()
-      .padding(MEDIUM_PADDING.dp)
-      .testTag("activityDetails")) {
+  Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("activityDetails")) {
     val vignette =
         if (activity.images.isNotEmpty()) {
           activity.images.first()
@@ -319,35 +300,28 @@ fun DisplayActivity(activity: Activity) {
         model = vignette,
         contentDescription = "Activity image",
         modifier =
-        Modifier
-            .fillMaxWidth()
-            .height(LARGE_IMAGE_SIZE.dp)
-            .clip(RoundedCornerShape(TEXT_FONTSIZE.dp))
-            .testTag("activityImage"),
+            Modifier.fillMaxWidth()
+                .height(LARGE_IMAGE_SIZE.dp)
+                .clip(RoundedCornerShape(TEXT_FONTSIZE.dp))
+                .testTag("activityImage"),
         contentScale = ContentScale.Crop)
     Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
     Text(
         text = activity.title,
         style = MaterialTheme.typography.bodyLarge,
-        modifier = Modifier
-            .padding(bottom = STANDARD_PADDING.dp)
-            .testTag("activityTitle"),
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityTitle"),
     )
     Text(
         text = activity.description,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .padding(bottom = STANDARD_PADDING.dp)
-            .testTag("activityDescription"),
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDescription"),
     )
     Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .padding(bottom = STANDARD_PADDING.dp)
-            .testTag("activityDate")) {
+        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDate")) {
           Icon(
               imageVector = Icons.Default.CalendarToday,
               contentDescription = "Date",
@@ -360,9 +334,7 @@ fun DisplayActivity(activity: Activity) {
     if (activity.location != null) {
       Row(
           verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier
-              .padding(bottom = STANDARD_PADDING.dp)
-              .testTag("activityLocation")) {
+          modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityLocation")) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
                 contentDescription = "Location",
@@ -378,9 +350,7 @@ fun DisplayActivity(activity: Activity) {
 
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("activityPrice")) {
+        modifier = Modifier.fillMaxWidth().testTag("activityPrice")) {
           Text(
               text = "Price: ${activity.price} CHF",
               style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -69,6 +69,7 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MapStyleOptions
+import com.google.firebase.Timestamp
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.Marker
@@ -94,7 +95,7 @@ fun MapScreen(
   var showBottomSheet by remember { mutableStateOf(false) }
   val previousScreen = navigationActions.getPreviousRoute()
   var showFilterDialog by remember { mutableStateOf(false) }
-  val hourDateViewModel: HourDateViewModel = HourDateViewModel()
+  val hourDateViewModel = HourDateViewModel()
   HandleLocationPermissionsAndTracking(locationViewModel = locationViewModel)
 
   val firstLocation =
@@ -116,34 +117,47 @@ fun MapScreen(
 
   Scaffold(
       floatingActionButton = {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = MEDIUM_PADDING.dp),
-            horizontalArrangement = Arrangement.SpaceBetween) {
-              FloatingActionButton(
-                  modifier =
-                      Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+          if(networkManager.isNetworkAvailable()) {
+              Row(
+                  modifier = Modifier
+                      .fillMaxWidth()
+                      .padding(horizontal = MEDIUM_PADDING.dp),
+                  horizontalArrangement = Arrangement.SpaceBetween
+              ) {
+                  FloatingActionButton(
+                      modifier =
+                      Modifier
+                          .padding(horizontal = MEDIUM_PADDING.dp)
                           .testTag("centerOnCurrentLocation"),
-                  onClick = {
-                    coroutineScope.launch {
-                      currentLocation?.let {
-                        val locationLatLng = LatLng(it.latitude, it.longitude)
-                        cameraPositionState.animate(
-                            update = CameraUpdateFactory.newLatLngZoom(locationLatLng, 15f),
-                            durationMs = 800)
-                      }
-                    }
-                  }) {
-                    Icon(
-                        Icons.Default.MyLocation, contentDescription = "Center on current location")
+                      onClick = {
+                          coroutineScope.launch {
+                              currentLocation?.let {
+                                  val locationLatLng = LatLng(it.latitude, it.longitude)
+                                  cameraPositionState.animate(
+                                      update = CameraUpdateFactory.newLatLngZoom(
+                                          locationLatLng,
+                                          15f
+                                      ),
+                                      durationMs = 800
+                                  )
+                              }
+                          }
+                      }) {
+                      Icon(
+                          Icons.Default.MyLocation,
+                          contentDescription = "Center on current location"
+                      )
                   }
-              FloatingActionButton(
-                  modifier =
-                      Modifier.padding(horizontal = MEDIUM_PADDING.dp)
+                  FloatingActionButton(
+                      modifier =
+                      Modifier
+                          .padding(horizontal = MEDIUM_PADDING.dp)
                           .testTag("filterDialogButton"),
-                  onClick = { showFilterDialog = true }) {
-                    Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
+                      onClick = { showFilterDialog = true }) {
+                      Icon(Icons.Default.DensityMedium, contentDescription = "Open filter dialog")
                   }
-            }
+              }
+          }
       },
       content = { padding ->
         if (!networkManager.isNetworkAvailable()) {
@@ -151,7 +165,10 @@ fun MapScreen(
         } else {
           Box(modifier = Modifier.fillMaxSize()) {
             GoogleMap(
-                modifier = Modifier.fillMaxSize().padding(padding).testTag("mapScreen"),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .testTag("mapScreen"),
                 cameraPositionState = cameraPositionState,
                 properties =
                     MapProperties(
@@ -160,7 +177,7 @@ fun MapScreen(
                   (activities as ListActivitiesViewModel.ActivitiesUiState.Success)
                       .activities
                       .filter {
-                        if (it.price > listActivitiesViewModel.maxPrice) false
+                        (if (it.price > listActivitiesViewModel.maxPrice) false
                         else if (listActivitiesViewModel.availablePlaces != null &&
                             (it.maxPlaces - it.placesLeft) <=
                                 listActivitiesViewModel.availablePlaces!!)
@@ -186,7 +203,8 @@ fun MapScreen(
                             false
                         else if (listActivitiesViewModel.onlyPRO && it.type != ActivityType.PRO)
                             false
-                        else it.location != null
+                        else it.location != null) && hourDateViewModel
+                            .combineDateAndTime(it.date, it.duration) > Timestamp.now()
                       }
                       .forEach { item ->
                         Marker(
@@ -259,9 +277,13 @@ fun MapScreen(
     ModalBottomSheet(
         onDismissRequest = { showBottomSheet = false },
     ) {
-      Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp)) {
+      Column(modifier = Modifier
+          .fillMaxWidth()
+          .padding(MEDIUM_PADDING.dp)) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(STANDARD_PADDING.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               SeeMoreDetailsButton(navigationActions)
@@ -283,7 +305,10 @@ fun MapScreen(
 
 @Composable
 fun DisplayActivity(activity: Activity) {
-  Column(modifier = Modifier.fillMaxWidth().padding(MEDIUM_PADDING.dp).testTag("activityDetails")) {
+  Column(modifier = Modifier
+      .fillMaxWidth()
+      .padding(MEDIUM_PADDING.dp)
+      .testTag("activityDetails")) {
     val vignette =
         if (activity.images.isNotEmpty()) {
           activity.images.first()
@@ -294,28 +319,35 @@ fun DisplayActivity(activity: Activity) {
         model = vignette,
         contentDescription = "Activity image",
         modifier =
-            Modifier.fillMaxWidth()
-                .height(LARGE_IMAGE_SIZE.dp)
-                .clip(RoundedCornerShape(TEXT_FONTSIZE.dp))
-                .testTag("activityImage"),
+        Modifier
+            .fillMaxWidth()
+            .height(LARGE_IMAGE_SIZE.dp)
+            .clip(RoundedCornerShape(TEXT_FONTSIZE.dp))
+            .testTag("activityImage"),
         contentScale = ContentScale.Crop)
     Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
     Text(
         text = activity.title,
         style = MaterialTheme.typography.bodyLarge,
-        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityTitle"),
+        modifier = Modifier
+            .padding(bottom = STANDARD_PADDING.dp)
+            .testTag("activityTitle"),
     )
     Text(
         text = activity.description,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDescription"),
+        modifier = Modifier
+            .padding(bottom = STANDARD_PADDING.dp)
+            .testTag("activityDescription"),
     )
     Spacer(modifier = Modifier.height(TEXT_FONTSIZE.dp))
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityDate")) {
+        modifier = Modifier
+            .padding(bottom = STANDARD_PADDING.dp)
+            .testTag("activityDate")) {
           Icon(
               imageVector = Icons.Default.CalendarToday,
               contentDescription = "Date",
@@ -328,7 +360,9 @@ fun DisplayActivity(activity: Activity) {
     if (activity.location != null) {
       Row(
           verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.padding(bottom = STANDARD_PADDING.dp).testTag("activityLocation")) {
+          modifier = Modifier
+              .padding(bottom = STANDARD_PADDING.dp)
+              .testTag("activityLocation")) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
                 contentDescription = "Location",
@@ -344,7 +378,9 @@ fun DisplayActivity(activity: Activity) {
 
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
-        modifier = Modifier.fillMaxWidth().testTag("activityPrice")) {
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("activityPrice")) {
           Text(
               text = "Price: ${activity.price} CHF",
               style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
This pull request includes several changes to the `Map.kt` file to improve the functionality and readability of the `MapScreen` function. The most important changes include adding a network availability check for the floating action button, modifying the `HourDateViewModel` initialization, and updating the filtering logic for activities.

Improvements to network availability checks:

* Added a check to display the floating action button only when the network is available. [[1]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R120) [[2]](diffhunk://#diff-ab516878181f6321486ac27b1e569366a5e5013e399698bee915ee80184a20c8R150)

Code readability improvements:

* Reformatted the `Icon` component for better readability.
* Modified the initialization of `HourDateViewModel` to remove explicit type declaration.

Enhancements to filtering logic:

* Updated the filtering logic to include a timestamp comparison using `hourDateViewModel.combineDateAndTime` and `Timestamp.now()`.
* Adjusted the filtering condition for activity prices.

Additionally, an import statement for `com.google.firebase.Timestamp` was added to support the new filtering logic.