### PR TITLE
Fix dismiss dialogs time and date when clicking the cancel button

### DIFF
--- a/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
@@ -423,7 +423,6 @@ fun ActivityForm(
                 "${dueDate.toDate().year + 1900}  (click to change)")
     else Text("Select Date for the activity")
   }
-  Spacer(modifier = Modifier.height(STANDARD_PADDING.dp))
   // Button to display the start time picker
   TextButton(
       onClick = onClickStartingTime,
@@ -437,9 +436,7 @@ fun ActivityForm(
     if (startTimeIsSet) Text("Start time: $startTime (click to change)")
     else Text("Select start time")
   }
-
-  Spacer(modifier = Modifier.width(STANDARD_PADDING.dp))
-  // Button to display the duration time picker
+    // Button to display the duration time picker
   TextButton(
       onClick = onClickDurationTime,
       modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp).testTag("inputEndTimeCreate"),

--- a/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt
@@ -436,7 +436,7 @@ fun ActivityForm(
     if (startTimeIsSet) Text("Start time: $startTime (click to change)")
     else Text("Select start time")
   }
-    // Button to display the duration time picker
+  // Button to display the duration time picker
   TextButton(
       onClick = onClickDurationTime,
       modifier = Modifier.fillMaxWidth().padding(STANDARD_PADDING.dp).testTag("inputEndTimeCreate"),

--- a/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
@@ -3,7 +3,6 @@ package com.android.sample.ui.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.window.DialogProperties
 import com.google.firebase.Timestamp
 import com.vanpra.composematerialdialogs.MaterialDialog
 import com.vanpra.composematerialdialogs.MaterialDialogState
@@ -27,15 +26,13 @@ fun MyDatePicker(
     initialDate: LocalDate?,
     onCloseRequest: (MaterialDialogState) -> Unit
 ) {
-    val dialogState = rememberMaterialDialogState(isOpen)
+  val dialogState = rememberMaterialDialogState(isOpen)
   MaterialDialog(
       onCloseRequest = onCloseRequest,
       dialogState = dialogState,
       buttons = {
         positiveButton("Ok")
-        negativeButton("Cancel"){
-            onCloseRequest(dialogState)
-        }
+        negativeButton("Cancel") { onCloseRequest(dialogState) }
       }) {
         datepicker(
             initialDate = initialDate ?: LocalDate.now(),

--- a/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/DatePicker.kt
@@ -27,13 +27,15 @@ fun MyDatePicker(
     initialDate: LocalDate?,
     onCloseRequest: (MaterialDialogState) -> Unit
 ) {
+    val dialogState = rememberMaterialDialogState(isOpen)
   MaterialDialog(
       onCloseRequest = onCloseRequest,
-      dialogState = rememberMaterialDialogState(isOpen),
-      properties = DialogProperties(dismissOnClickOutside = true, dismissOnBackPress = true),
+      dialogState = dialogState,
       buttons = {
         positiveButton("Ok")
-        negativeButton("Cancel")
+        negativeButton("Cancel"){
+            onCloseRequest(dialogState)
+        }
       }) {
         datepicker(
             initialDate = initialDate ?: LocalDate.now(),

--- a/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
@@ -29,7 +29,6 @@ fun MyTimePicker(
   MaterialDialog(
       onCloseRequest = onCloseRequest,
       dialogState = dialogState,
-      properties = DialogProperties(dismissOnClickOutside = true, dismissOnBackPress = true),
       buttons = {
         positiveButton(text = "Ok")
         negativeButton(text = "Cancel"){

--- a/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
@@ -25,13 +25,16 @@ fun MyTimePicker(
     onCloseRequest: (MaterialDialogState) -> Unit,
     isAmPm: Boolean = true
 ) {
+    val dialogState = rememberMaterialDialogState(isOpen)
   MaterialDialog(
       onCloseRequest = onCloseRequest,
-      dialogState = rememberMaterialDialogState(isOpen),
+      dialogState = dialogState,
       properties = DialogProperties(dismissOnClickOutside = true, dismissOnBackPress = true),
       buttons = {
         positiveButton(text = "Ok")
-        negativeButton(text = "Cancel")
+        negativeButton(text = "Cancel"){
+            onCloseRequest(dialogState)
+        }
       }) {
         timepicker(
             initialTime = LocalTime.now().truncatedTo(java.time.temporal.ChronoUnit.MINUTES),

--- a/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TimePicker.kt
@@ -1,7 +1,6 @@
 package com.android.sample.ui.components
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.window.DialogProperties
 import com.google.firebase.Timestamp
 import com.vanpra.composematerialdialogs.MaterialDialog
 import com.vanpra.composematerialdialogs.MaterialDialogState
@@ -25,15 +24,13 @@ fun MyTimePicker(
     onCloseRequest: (MaterialDialogState) -> Unit,
     isAmPm: Boolean = true
 ) {
-    val dialogState = rememberMaterialDialogState(isOpen)
+  val dialogState = rememberMaterialDialogState(isOpen)
   MaterialDialog(
       onCloseRequest = onCloseRequest,
       dialogState = dialogState,
       buttons = {
         positiveButton(text = "Ok")
-        negativeButton(text = "Cancel"){
-            onCloseRequest(dialogState)
-        }
+        negativeButton(text = "Cancel") { onCloseRequest(dialogState) }
       }) {
         timepicker(
             initialTime = LocalTime.now().truncatedTo(java.time.temporal.ChronoUnit.MINUTES),


### PR DESCRIPTION
This pull request includes several changes to improve the UI components and layout in the `ActivityForm`, `DatePicker`, and `TimePicker` files. The most important changes involve the removal of unnecessary spacers, the refactoring of dialog state management, and the cleanup of unused imports.

### UI Layout Improvements:

* [`app/src/main/java/com/android/sample/ui/activity/ActivityForm.kt`](diffhunk://#diff-c90afeca023e6ef757d365cc9cd44bdd11274ec181f385e50a91c0b67dfcd1a8L426): Removed unnecessary spacers to improve the layout and spacing. [[1]](diffhunk://#diff-c90afeca023e6ef757d365cc9cd44bdd11274ec181f385e50a91c0b67dfcd1a8L426) [[2]](diffhunk://#diff-c90afeca023e6ef757d365cc9cd44bdd11274ec181f385e50a91c0b67dfcd1a8L440-L441)

### Dialog State Management:

* [`app/src/main/java/com/android/sample/ui/components/DatePicker.kt`](diffhunk://#diff-e80beb97f75e27602d3244da282bfdb75b9b48e9945596c6bb03bd47e2b07ac6R29-R35): Refactored `MyDatePicker` to initialize `dialogState` before the `MaterialDialog` and adjusted the `negativeButton` to properly handle the close request.
* [`app/src/main/java/com/android/sample/ui/components/TimePicker.kt`](diffhunk://#diff-2f72a5325557db7b590505bc96bcbf5fc1d204d50a62e3b2ce761b5b4dcb9762R27-R33): Refactored `MyTimePicker` to initialize `dialogState` before the `MaterialDialog` and adjusted the `negativeButton` to properly handle the close request.

### Code Cleanup:

* [`app/src/main/java/com/android/sample/ui/components/DatePicker.kt`](diffhunk://#diff-e80beb97f75e27602d3244da282bfdb75b9b48e9945596c6bb03bd47e2b07ac6L6): Removed unused import `DialogProperties`.
* [`app/src/main/java/com/android/sample/ui/components/TimePicker.kt`](diffhunk://#diff-2f72a5325557db7b590505bc96bcbf5fc1d204d50a62e3b2ce761b5b4dcb9762L4): Removed unused import `DialogProperties`.