### PR TITLE
fix : images positions will not be swapped in activity details, and image displayed on activity card stays the same

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/camera/CarouselTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/camera/CarouselTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.android.sample.model.image.resize
+import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,5 +45,26 @@ class CarouselTest {
     composeTestRule.onNodeWithTag("addImageButton").performClick()
     // Verify that the openDialog function is called
     // You may need to use a spy or a verification mechanism depending on the implementation
+  }
+
+  @Test
+  fun testResize() {
+    val originalWidth = 100
+    val originalHeight = 50
+    val reqWidth = 50
+
+    // Create a mock Bitmap with specific dimensions
+
+    // Calculate the expected height based on the required width
+    val ratio = originalWidth.toFloat() / originalHeight.toFloat()
+    val expectedHeight = (reqWidth / ratio).toInt()
+
+    val originalBitmap = Bitmap.createBitmap(originalWidth, originalHeight, Bitmap.Config.ARGB_8888)
+    // Perform the resize
+    val resizedBitmap = originalBitmap.resize(reqWidth)
+
+    // Verify the dimensions
+    assertEquals(reqWidth, resizedBitmap.width)
+    assertEquals(expectedHeight, resizedBitmap.height)
   }
 }

--- a/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/image/ImageRepositoryFirestore.kt
@@ -224,7 +224,7 @@ constructor(private val firestore: FirebaseFirestore, private val storage: Fireb
         .addOnFailureListener { onFailure(it) }
   }
 
-  private fun sortUrlsByTimestamp(urls: List<String>): List<String> {
+  fun sortUrlsByTimestamp(urls: List<String>): List<String> {
     return urls.sortedBy { url ->
       // Extract the timestamp part from the URL
       url.substringAfterLast("image_").substringBefore('.').toLongOrNull() ?: 0L

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -122,13 +122,9 @@ fun EditActivityScreen(
   var selectedImages by remember { mutableStateOf<List<Bitmap>>(emptyList()) }
   var items by remember { mutableStateOf(activity?.images ?: listOf()) }
   LaunchedEffect(activity!!.uid) {
-    Log.d("EditActivityScreen", "Fetching images for activity: ${activity.uid}")
     imageViewModel.fetchActivityImagesAsBitmaps(
         activity.uid,
-        { bitmaps ->
-          selectedImages = bitmaps.toMutableStateList()
-          Log.d("EditActivityScreen", "Fetched images successfully for activity: ${activity.uid}")
-        },
+        { bitmaps -> selectedImages = bitmaps.toMutableStateList() },
         onFailure = { error ->
           Log.e("EditActivityScreen", "Failed to fetch images: ${error.message}")
         })

--- a/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
+++ b/app/src/main/java/com/android/sample/ui/activity/EditActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -85,7 +86,7 @@ fun EditActivityScreen(
     imageViewModel: ImageViewModel,
     profileViewModel: ProfileViewModel
 ) {
-  val hourDateViewModel: HourDateViewModel = HourDateViewModel()
+  val hourDateViewModel = HourDateViewModel()
   val context = LocalContext.current
   var showDialog by remember { mutableStateOf(false) }
   var showDialogImage by remember { mutableStateOf(false) }
@@ -102,7 +103,6 @@ fun EditActivityScreen(
   var attendees by remember { mutableStateOf(activity?.participants!!) }
   var startTime by remember { mutableStateOf(activity?.startTime) }
   var duration by remember { mutableStateOf(activity?.duration ?: "00:01") }
-  var expanded by remember { mutableStateOf(false) }
   var selectedOption by remember { mutableStateOf(activity?.type.toString()) }
   var expandedType by remember { mutableStateOf(false) }
   var expandedCategory by remember { mutableStateOf(false) }
@@ -121,12 +121,18 @@ fun EditActivityScreen(
   var isGalleryOpen by remember { mutableStateOf(false) }
   var selectedImages by remember { mutableStateOf<List<Bitmap>>(emptyList()) }
   var items by remember { mutableStateOf(activity?.images ?: listOf()) }
-  imageViewModel.fetchActivityImagesAsBitmaps(
-      activity?.uid ?: "",
-      { bitmaps -> selectedImages = bitmaps.toMutableStateList() },
-      onFailure = { error ->
-        Log.e("EditActivityScreen", "Failed to fetch images: ${error.message}")
-      })
+  LaunchedEffect(activity!!.uid) {
+    Log.d("EditActivityScreen", "Fetching images for activity: ${activity.uid}")
+    imageViewModel.fetchActivityImagesAsBitmaps(
+        activity.uid,
+        { bitmaps ->
+          selectedImages = bitmaps.toMutableStateList()
+          Log.d("EditActivityScreen", "Fetched images successfully for activity: ${activity.uid}")
+        },
+        onFailure = { error ->
+          Log.e("EditActivityScreen", "Failed to fetch images: ${error.message}")
+        })
+  }
   // Handle the error, e.g., show a Toast or log the exception
   var dueDate by remember { mutableStateOf(activity?.date ?: Timestamp.now()) }
   var dateIsOpen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -199,6 +200,18 @@ fun ActivityDetailsScreen(
                     .verticalScroll(rememberScrollState())
                     .testTag("activityDetailsScreen")) {
               // Image section
+              LaunchedEffect(activity!!.uid) {
+                Log.d("ActivityDetailsScreen", "Fetching images for activity ${activity.uid}")
+                imageViewModel.fetchActivityImagesAsBitmaps(
+                    activity.uid,
+                    onSuccess = { urls ->
+                      bitmaps = urls
+                      Log.d(
+                          "ActivityDetailsScreen",
+                          "Fetched images successfully for activity ${activity.uid}")
+                    },
+                    onFailure = { Log.e("ActivityDetailsScreen", it.message.toString()) })
+              }
               Box(
                   modifier =
                       Modifier.fillMaxWidth()
@@ -206,15 +219,7 @@ fun ActivityDetailsScreen(
                           .padding(MEDIUM_PADDING.dp)
                           .background(Color.Gray, shape = RoundedCornerShape(STANDARD_PADDING.dp))
                           .testTag("image")) {
-                    imageViewModel.fetchActivityImagesAsBitmaps(
-                        activity?.uid ?: "",
-                        onSuccess = { urls -> bitmaps = urls },
-                        onFailure = { Log.e("ActivityDetailsScreen", it.message.toString()) })
-                    if (activity !=
-                        null) { // to avoid setting a default category in the case where activity is
-                      // null which should never be the case
-                      CarouselNoModif(itemsList = bitmaps, category = activity.category)
-                    }
+                    CarouselNoModif(itemsList = bitmaps, category = activity.category)
                     LikeButton(profile, activity, profileViewModel)
                   }
 

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -201,15 +201,9 @@ fun ActivityDetailsScreen(
                     .testTag("activityDetailsScreen")) {
               // Image section
               LaunchedEffect(activity!!.uid) {
-                Log.d("ActivityDetailsScreen", "Fetching images for activity ${activity.uid}")
                 imageViewModel.fetchActivityImagesAsBitmaps(
                     activity.uid,
-                    onSuccess = { urls ->
-                      bitmaps = urls
-                      Log.d(
-                          "ActivityDetailsScreen",
-                          "Fetched images successfully for activity ${activity.uid}")
-                    },
+                    onSuccess = { urls -> bitmaps = urls },
                     onFailure = { Log.e("ActivityDetailsScreen", it.message.toString()) })
               }
               Box(

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -3,6 +3,7 @@ package com.android.sample.ui.profile
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -205,8 +206,16 @@ fun ActivityRow(
       verticalAlignment = Alignment.Top) {
         var bitmaps by remember { mutableStateOf(listOf<Bitmap>()) }
 
-        imageViewModel.fetchActivityImagesAsBitmaps(
-            activity.uid, onSuccess = { urls -> bitmaps = urls }, onFailure = {})
+        LaunchedEffect(user) {
+          Log.d("ActivityRow", "Fetching images for activity ${activity.uid}")
+          imageViewModel.fetchActivityImagesAsBitmaps(
+              activity.uid,
+              onSuccess = { urls ->
+                bitmaps = urls
+                Log.d("ActivityRow", "Fetched images successfully for activity ${activity.uid}")
+              },
+              onFailure = {})
+        }
 
         // Display image
         if (activity.images.isNotEmpty() && bitmaps.isNotEmpty()) {

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -3,7 +3,6 @@ package com.android.sample.ui.profile
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -207,14 +206,8 @@ fun ActivityRow(
         var bitmaps by remember { mutableStateOf(listOf<Bitmap>()) }
 
         LaunchedEffect(user) {
-          Log.d("ActivityRow", "Fetching images for activity ${activity.uid}")
           imageViewModel.fetchActivityImagesAsBitmaps(
-              activity.uid,
-              onSuccess = { urls ->
-                bitmaps = urls
-                Log.d("ActivityRow", "Fetched images successfully for activity ${activity.uid}")
-              },
-              onFailure = {})
+              activity.uid, onSuccess = { urls -> bitmaps = urls }, onFailure = {})
         }
 
         // Display image

--- a/app/src/test/java/com/android/sample/model/image/ImageRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/image/ImageRepositoryFirestoreTest.kt
@@ -467,6 +467,25 @@ class ImageRepositoryFirestoreTest {
   }
 
   @Test
+  fun testSortUrlsByTimestamp() {
+    // Given: A list of URLs with embedded timestamps
+    val urls =
+        listOf(
+            "https://example.com/o/image_1734567209436.jpg?alt=media",
+            "https://example.com/o/image_1734567209401.jpg?alt=media",
+            "https://example.com/o/image_1734567209411.jpg?alt=media")
+    // When: Sorting the URLs by timestamp
+    val sortedUrls = imageRepository.sortUrlsByTimestamp(urls)
+    // Then: The URLs should be sorted by their timestamps in ascending order
+    val expected =
+        listOf(
+            "https://example.com/o/image_1734567209401.jpg?alt=media",
+            "https://example.com/o/image_1734567209411.jpg?alt=media",
+            "https://example.com/o/image_1734567209436.jpg?alt=media")
+    assertEquals(expected, sortedUrls)
+  }
+
+  @Test
   fun fetchActivityImagesAsBitmaps_success() {
     val activityId = "activityId"
     val expectedUrls = listOf("https://example.com/image1.jpg", "https://example.com/image2.jpg")


### PR DESCRIPTION
If i go back then come again, the images may have a different order as their last because the fetching of the images returns the bitmaps in a "random" order, not predictable.
Edit : The solution used is to sort the Urls when fetched, then treat them sorted by TimeStamp order, when converting urls to bitmaps, so thht the returned list has the same order as the url list. The order is done according the timestamp of each picture, so that the ordering stays consistent. Now the list of images keeps the same order in activity details, even if fyou get out and go back the screen, also the first picture of an image which is displayed on the activity card stays the same thanks to this ordering.

The only problem, is that when an image is removed or added, all the other images are removed then put back, even though we did not touch them( this the logic implemented in upload activity images). So if I change the pictures, the order will change, but this new order will stay consistent everywhere until images are changed again. This cannot be resolved now because it would change the logic of uploading images for activities, so that could have been done if there was more time to work on it.