### PR TITLE
Fixed disposition of past activities on profile and navigation 

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -174,6 +174,10 @@ fun NavGraph(
       composable(Screen.MAP) {
         MapScreen(navigationActions, locationViewModel, listActivitiesViewModel)
       }
+      composable(Screen.OVERVIEW) {
+        ListActivitiesScreen(
+            listActivitiesViewModel, navigationActions, profileViewModel, locationViewModel)
+      }
     }
 
     navigation(startDestination = Screen.ADD_ACTIVITY, route = Route.ADD_ACTIVITY) {

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -573,18 +573,14 @@ fun DisplayActivitiesList(
       listToShow =
           userActivities.filter {
             it.creator == user.id &&
-                hourDateViewModel.combineDateAndTime(
-                    it.date, hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
-                    Timestamp.now()
+                hourDateViewModel.combineDateAndTime(it.date, it.startTime) > Timestamp.now()
           }
     }
     ENROLLED_ACTIVITIES -> {
       listToShow =
           userActivities.filter {
             (it.creator != user.id || it.participants.map { it.id }.contains(user.id)) &&
-                hourDateViewModel.combineDateAndTime(
-                    it.date, hourDateViewModel.addDurationToTime(it.startTime, it.duration)) >
-                    Timestamp.now()
+                hourDateViewModel.combineDateAndTime(it.date, it.startTime) > Timestamp.now()
           }
     }
   }


### PR DESCRIPTION
This pull request includes changes to the navigation and filtering logic in the `MainActivity.kt` and `Profile.kt` files. The most important changes are the addition of a new screen to the navigation graph and the simplification of the date and time filtering logic.

### Navigation updates:

* [`app/src/main/java/com/android/sample/MainActivity.kt`](diffhunk://#diff-0859fc4e472afc96e90cddd4bc16c22a149a751d8794a52a66c5053ec043660dR177-R180): Added a new `composable` for the `Screen.OVERVIEW` to the navigation graph, which includes `ListActivitiesScreen` with additional view models.

### Filtering logic simplification:

* [`app/src/main/java/com/android/sample/ui/profile/Profile.kt`](diffhunk://#diff-85815712ce6132fb0dc1814029867b9878cfd00e4b6372c34d6610e219cf0266L576-R583): Simplified the filtering logic in `DisplayActivitiesList` by removing the addition of duration to the start time in the `combineDateAndTime` method calls.