### PR TITLE
Fix/default profile picture selector

### DIFF
--- a/app/src/main/java/com/android/sample/resources/C.kt
+++ b/app/src/main/java/com/android/sample/resources/C.kt
@@ -29,7 +29,7 @@ object C {
     const val ENROLLED_ACTIVITIES = 1
     const val PAST_ACTIVITIES = 2
 
-    const val CARD_IAMGES_SIZE = 120
+    const val CARD_IAMGES_SIZE = 100
     const val STANDARD_PADDING = 8
 
     const val MEDIUM_FONTSIZE = 18

--- a/app/src/main/java/com/android/sample/ui/camera/Gallery.kt
+++ b/app/src/main/java/com/android/sample/ui/camera/Gallery.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -88,7 +89,10 @@ fun DefaultImageCarousel(
   Dialog(onDismissRequest = onDismiss) {
     Card(
         shape = RoundedCornerShape(MEDIUM_PADDING.dp),
-        modifier = Modifier.padding(MEDIUM_PADDING.dp).testTag("DefaultImageCarousel")) {
+        modifier =
+            Modifier.width((2 * CARD_IAMGES_SIZE).dp)
+                .padding(MEDIUM_PADDING.dp)
+                .testTag("DefaultImageCarousel")) {
           Column(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = "Select an Image",


### PR DESCRIPTION
- In this Pull Request, I reduced the size of the carousel where default images are displayed, so that the 2nd image can appear only in half suggesting that it is scrollable.
 - Also I reduced the size of the displayed images in carousel because they were too big.