### PR TITLE
Fix reliability on code for list activities viewmodel

### DIFF
--- a/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
@@ -362,7 +362,7 @@ constructor(
     val weights = getWeights()
     val totalWeights = weights.values.sum()
 
-    if (cachedScores_.containsKey(activity.uid)) return cachedScores_[activity.uid]!!
+    if (cachedScores_.containsKey(activity.uid)) return cachedScores_[activity.uid]?:2.5
 
     val distanceScore = calculateDistanceScore(distanceTo(activity.location))
     val dateScore = calculateDateScore(activity.date)

--- a/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt
@@ -362,7 +362,7 @@ constructor(
     val weights = getWeights()
     val totalWeights = weights.values.sum()
 
-    if (cachedScores_.containsKey(activity.uid)) return cachedScores_[activity.uid]?:2.5
+    if (cachedScores_.containsKey(activity.uid)) return cachedScores_[activity.uid] ?: 2.5
 
     val distanceScore = calculateDistanceScore(distanceTo(activity.location))
     val dateScore = calculateDateScore(activity.date)


### PR DESCRIPTION
This pull request includes a minor change to the `ListActivitiesViewModel.kt` file to handle null values more gracefully. The change modifies the return statement in the `constructor` method to use the Elvis operator for providing a default value.

* [`app/src/main/java/com/android/sample/model/activity/ListActivitiesViewModel.kt`](diffhunk://#diff-b58b26be32e996bbb8e363fd3a9b6c10fdca142ceac60837596e81a521eddaf0L365-R365): Modified the return statement to use the Elvis operator `?:` to return a default value of `2.5` if `cachedScores_[activity.uid]` is null.