### PR TITLE
fix(profile): adjust logic to compute activities joined.

### DIFF
--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -642,9 +642,10 @@ fun ProfileHeader(user: User, imageViewModel: ImageViewModel, userActivities: Li
           HeaderItem(
               "Activities\nJoined",
               userActivities
-                  .filter({
-                    it.creator != user.id || it.participants.map { it.id }.contains(user.id)
-                  })
+                  .filter { activity ->
+                    activity.creator != user.id &&
+                        activity.participants.map { it.id }.contains(user.id)
+                  }
                   .size
                   .toString(),
               false)


### PR DESCRIPTION
In this PR, I just updated the wrong logic that was done for computing the already joined activities:
```kotlin
it.creator != user.id || it.participants.map "{ it.id }.contains(user.id)
``` 
If you see here, the || condition is wrong and had to be replaced by a && condition so that an activity that contains our user id doesn't count as joined in all cases (if you create an activity, your uid will be in it and this logic will think that you have joined and not created the activity)