### PR TITLE
fix(hour-date): return date of the event in case of hour and time combination

### DIFF
--- a/app/src/main/java/com/android/sample/model/hour_date/HourDateViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/hour_date/HourDateViewModel.kt
@@ -64,12 +64,7 @@ open class HourDateViewModel : ViewModel() {
       return Timestamp(
           combinedDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() / 1000, 0)
     } catch (e: DateTimeParseException) {
-      // Log the error or handle it as needed
-      println("Failed to parse time, error: ${e.message}")
-      val defaultDateTime = LocalDateTime.now()
-      return Timestamp(
-          defaultDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() / 1000,
-          0) // Or return a default Timestamp if that fits your use case
+      return date // Return a default Timestamp if that doesn't work
     }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -1,7 +1,6 @@
 package com.android.sample.ui.listActivities
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -215,7 +214,6 @@ fun ListActivitiesScreen(
                 activitiesList =
                     activitiesList.filter {
                       // log the activity to see which one faisl in combine date and time
-                      Log.d("Overview", "${it.title}")
                       val activityTimestamp =
                           hourDateViewModel.combineDateAndTime(
                               it.date, it.startTime) // Combine date and startTime


### PR DESCRIPTION
In this PR, I just changed the return value of combineDateAndTime in case of an error.
This should never happen and was happening before just because of an activity that was reated directly in the database and that didn't have a time field. However, now we cannot create activities without date/time anymore.