### PR TITLE
Fix/activity principal image overview

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activity/LikedActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activity/LikedActivitiesTest.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.activity
 
+import android.content.SharedPreferences
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -7,6 +8,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.android.sample.model.activity.ActivitiesRepository
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.image.ImageRepositoryFirestore
+import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.resources.dummydata.testUser
@@ -30,6 +33,9 @@ class LikedActivitiesTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var viewModel: ListActivitiesViewModel
   private lateinit var profileViewModel: ProfileViewModel
+  private lateinit var imageRepositoryFirestore: ImageRepositoryFirestore
+  private lateinit var sharedPreferences: SharedPreferences
+  private lateinit var imageViewModel: ImageViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -41,14 +47,11 @@ class LikedActivitiesTest {
     navigationActions = mock(NavigationActions::class.java)
     viewModel = ListActivitiesViewModel(profilesRepository, activitiesRepository)
 
-    // val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)
-
-    // `when`(userProfileViewModel.userState).thenReturn(userStateFlow)
-
+    imageRepositoryFirestore = mock(ImageRepositoryFirestore::class.java)
+    sharedPreferences = mock(SharedPreferences::class.java)
+    imageViewModel = ImageViewModel(imageRepositoryFirestore, sharedPreferences)
     `when`(navigationActions.currentRoute()).thenReturn(Route.LIKED_ACTIVITIES)
-    // composeTestRule.setContent { ListActivitiesScreen(listActivitiesViewModel, navigationActions,
-    // userProfileViewModel) }
   }
 
   @Test
@@ -58,7 +61,8 @@ class LikedActivitiesTest {
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(null))
 
     composeTestRule.setContent {
-      LikedActivitiesScreen(viewModel, navigationActions, profileViewModel)
+      LikedActivitiesScreen(
+          viewModel, navigationActions, profileViewModel, imageViewModel = imageViewModel)
     }
 
     // Verify sign-in prompt is displayed
@@ -76,7 +80,8 @@ class LikedActivitiesTest {
     whenever(profileViewModel.userState).thenReturn(MutableStateFlow(emptyTestUser))
 
     composeTestRule.setContent {
-      LikedActivitiesScreen(viewModel, navigationActions, profileViewModel)
+      LikedActivitiesScreen(
+          viewModel, navigationActions, profileViewModel, imageViewModel = imageViewModel)
     }
 
     // Verify empty liked activity message is displayed

--- a/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/listActivities/ListActivitiesTest.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.listActivities
 
+import android.content.SharedPreferences
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsOff
@@ -22,6 +23,8 @@ import com.android.sample.model.activity.ActivityStatus
 import com.android.sample.model.activity.ActivityType
 import com.android.sample.model.activity.Category
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.image.ImageRepositoryFirestore
+import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.map.Location
 import com.android.sample.model.map.LocationRepository
 import com.android.sample.model.map.LocationViewModel
@@ -52,6 +55,9 @@ class OverviewScreenTest {
   private lateinit var listActivitiesViewModel: ListActivitiesViewModel
   private lateinit var userProfileViewModel: ProfileViewModel
   private lateinit var locationViewModel: LocationViewModel
+  private lateinit var imageRepositoryFirestore: ImageRepositoryFirestore
+  private lateinit var sharedPreferences: SharedPreferences
+  private lateinit var imageViewModel: ImageViewModel
   private lateinit var testUser: User
 
   private val activity =
@@ -105,7 +111,9 @@ class OverviewScreenTest {
     activitiesRepository = mock(ActivitiesRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
     listActivitiesViewModel = ListActivitiesViewModel(profilesRepository, activitiesRepository)
-
+    imageRepositoryFirestore = mock(ImageRepositoryFirestore::class.java)
+    sharedPreferences = mock(SharedPreferences::class.java)
+    imageViewModel = ImageViewModel(imageRepositoryFirestore, sharedPreferences)
     testUser =
         User(
             id = "Rola",
@@ -134,7 +142,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     `when`(activitiesRepository.getActivities(any(), any())).then {
       it.getArgument<(List<Activity>) -> Unit>(0)(listOf())
@@ -150,7 +162,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     // Mock the activities repository to return an activity
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -177,7 +193,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     // Ensure segmented buttons are displayed
     composeTestRule.onNodeWithTag("segmentedButtonRow").assertIsDisplayed()
@@ -197,7 +217,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     composeTestRule.onNodeWithText("CULTURE").performClick()
     composeTestRule
@@ -211,7 +235,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     val fullActivity = activity.copy(maxPlaces = 2, placesLeft = 2)
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -229,7 +257,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     // Ensure bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
@@ -243,7 +275,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -265,7 +301,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     val activity1 = activity.copy(title = "Italian cooking", category = Category.CULTURE)
     val activity2 = activity.copy(title = "dance", category = Category.ENTERTAINMENT)
@@ -306,7 +346,8 @@ class OverviewScreenTest {
           listActivitiesViewModel = listActivitiesViewModel,
           profileViewModel = userProfileViewModel,
           profile = testUser,
-          activity = activity)
+          activity = activity,
+          imageViewModel = imageViewModel)
     }
     composeTestRule.onNodeWithTag("activityCard").assertIsDisplayed()
     composeTestRule.onNodeWithTag("iconparticipants", useUnmergedTree = true).assertIsDisplayed()
@@ -324,7 +365,8 @@ class OverviewScreenTest {
           listActivitiesViewModel = listActivitiesViewModel,
           profileViewModel = userProfileViewModel,
           profile = testUser,
-          activity = activity)
+          activity = activity,
+          imageViewModel = imageViewModel)
     }
     composeTestRule.onNodeWithTag("activityCard").assertIsDisplayed()
     composeTestRule.onNodeWithTag("participantsText", useUnmergedTree = true).assertIsDisplayed()
@@ -346,7 +388,8 @@ class OverviewScreenTest {
           listActivitiesViewModel = listActivitiesViewModel,
           profileViewModel = userProfileViewModel,
           profile = testUser,
-          activity = activity1)
+          activity = activity1,
+          imageViewModel = imageViewModel)
     }
 
     composeTestRule.onNodeWithTag("activityCard").assertIsDisplayed()
@@ -363,7 +406,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     `when`(activitiesRepository.getActivities(any(), any())).then {
       it.getArgument<(List<Activity>) -> Unit>(0)(listOf(activity))
@@ -386,7 +433,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(newUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     composeTestRule.onNodeWithTag("likeButtontrue").assertIsDisplayed()
@@ -402,7 +453,8 @@ class OverviewScreenTest {
           profileViewModel = userProfileViewModel,
           profile = testUser,
           activity = activity,
-          distance = 0.5503f)
+          distance = 0.5503f,
+          imageViewModel = imageViewModel)
     }
     composeTestRule
         .onNodeWithTag("locationAndDistanceText", useUnmergedTree = true)
@@ -419,7 +471,8 @@ class OverviewScreenTest {
           profileViewModel = userProfileViewModel,
           profile = testUser,
           activity = activity,
-          distance = 12.354f)
+          distance = 12.354f,
+          imageViewModel = imageViewModel)
     }
     composeTestRule
         .onNodeWithTag("locationAndDistanceText", useUnmergedTree = true)
@@ -436,7 +489,8 @@ class OverviewScreenTest {
           profileViewModel = userProfileViewModel,
           profile = testUser,
           activity = activity,
-          distance = null)
+          distance = null,
+          imageViewModel = imageViewModel)
     }
     composeTestRule
         .onNodeWithTag("locationAndDistanceText", useUnmergedTree = true)
@@ -453,7 +507,8 @@ class OverviewScreenTest {
           listActivitiesViewModel = listActivitiesViewModel,
           profileViewModel = userProfileViewModel,
           profile = testUser,
-          activity = activity)
+          activity = activity,
+          imageViewModel = imageViewModel)
     }
 
     // Verify initial state is liked
@@ -477,7 +532,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     val activity1 = activity.copy(title = "cooking", type = ActivityType.INDIVIDUAL)
     val activity2 = activity.copy(title = "dance", type = ActivityType.PRO)
@@ -501,7 +560,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
     val activity1 = activity.copy(title = "cooking", type = ActivityType.INDIVIDUAL)
     val activity2 = activity.copy(title = "dance", type = ActivityType.PRO)
@@ -531,7 +594,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     val activity1 = activity.copy(title = "Few spots", maxPlaces = 5)
@@ -560,7 +627,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     val activity1 = activity.copy(title = "PRO activity", type = ActivityType.PRO)
@@ -588,7 +659,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     val activity1 =
@@ -618,7 +693,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(creatorProfile))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -649,7 +728,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -678,7 +761,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(user))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     `when`(activitiesRepository.getActivities(any(), any())).then {
@@ -711,7 +798,11 @@ class OverviewScreenTest {
     `when`(userProfileViewModel.userState).thenReturn(MutableStateFlow(creatorProfile))
     composeTestRule.setContent {
       ListActivitiesScreen(
-          listActivitiesViewModel, navigationActions, userProfileViewModel, locationViewModel)
+          listActivitiesViewModel,
+          navigationActions,
+          userProfileViewModel,
+          locationViewModel,
+          imageViewModel = imageViewModel)
     }
 
     `when`(activitiesRepository.getActivities(any(), any())).then {

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -146,7 +146,11 @@ fun NavGraph(
     ) {
       composable(Screen.OVERVIEW) {
         ListActivitiesScreen(
-            listActivitiesViewModel, navigationActions, profileViewModel, locationViewModel)
+            listActivitiesViewModel,
+            navigationActions,
+            profileViewModel,
+            locationViewModel,
+            imageViewModel = imageViewModel)
       }
       composable(Screen.EDIT_ACTIVITY) {
         EditActivityScreen(
@@ -176,7 +180,11 @@ fun NavGraph(
       }
       composable(Screen.OVERVIEW) {
         ListActivitiesScreen(
-            listActivitiesViewModel, navigationActions, profileViewModel, locationViewModel)
+            listActivitiesViewModel,
+            navigationActions,
+            profileViewModel,
+            locationViewModel,
+            imageViewModel = imageViewModel)
       }
     }
 
@@ -206,7 +214,11 @@ fun NavGraph(
 
     navigation(startDestination = Screen.LIKED_ACTIVITIES, route = Route.LIKED_ACTIVITIES) {
       composable(Screen.LIKED_ACTIVITIES) {
-        LikedActivitiesScreen(listActivitiesViewModel, navigationActions, profileViewModel)
+        LikedActivitiesScreen(
+            listActivitiesViewModel,
+            navigationActions,
+            profileViewModel,
+            imageViewModel = imageViewModel)
       }
     }
   }

--- a/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/LikedActivities.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.network.NetworkManager
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
@@ -48,6 +49,7 @@ fun LikedActivitiesScreen(
     navigationActions: NavigationActions,
     profileViewModel: ProfileViewModel,
     modifier: Modifier = Modifier,
+    imageViewModel: ImageViewModel
 ) {
   val uiState by viewModel.uiState.collectAsState()
   val profile = profileViewModel.userState.collectAsState().value
@@ -133,7 +135,8 @@ fun LikedActivitiesScreen(
                               viewModel,
                               profileViewModel,
                               profile,
-                              null)
+                              null,
+                              imageViewModel = imageViewModel)
                         }
                       }
                 }

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -618,7 +618,3 @@ fun DarkGradient() {
                       startY = START_Y,
                       endY = END_Y)))
 }
-
-fun Bitmap.resizeToFixedSize(width: Int, height: Int): Bitmap {
-  return Bitmap.createScaledBitmap(this, width, height, true)
-}

--- a/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
+++ b/app/src/main/java/com/android/sample/ui/listActivities/ViewListActivities.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.listActivities
 
 import android.annotation.SuppressLint
+import android.graphics.Bitmap
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -38,6 +39,7 @@ import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -49,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -64,6 +67,7 @@ import com.android.sample.model.activity.CategoryColorMap
 import com.android.sample.model.activity.ListActivitiesViewModel
 import com.android.sample.model.activity.categories
 import com.android.sample.model.hour_date.HourDateViewModel
+import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.map.HandleLocationPermissionsAndTracking
 import com.android.sample.model.map.LocationViewModel
 import com.android.sample.model.profile.ProfileViewModel
@@ -104,7 +108,8 @@ fun ListActivitiesScreen(
     navigationActions: NavigationActions,
     profileViewModel: ProfileViewModel,
     locationViewModel: LocationViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    imageViewModel: ImageViewModel
 ) {
   val uiState by viewModel.uiState.collectAsState()
   val options = categories.map { it.name }
@@ -290,7 +295,8 @@ fun ListActivitiesScreen(
                                 viewModel,
                                 profileViewModel,
                                 profile,
-                                locationViewModel.getDistanceFromCurrentLocation(activity.location))
+                                locationViewModel.getDistanceFromCurrentLocation(activity.location),
+                                imageViewModel = imageViewModel)
                           }
                         }
                       }
@@ -315,7 +321,8 @@ fun ActivityCard(
     listActivitiesViewModel: ListActivitiesViewModel,
     profileViewModel: ProfileViewModel,
     profile: User?,
-    distance: Float? = null
+    distance: Float? = null,
+    imageViewModel: ImageViewModel
 ) {
   val dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
   val formattedDate = dateFormat.format(activity.date.toDate())
@@ -338,13 +345,26 @@ fun ActivityCard(
         Column(modifier = Modifier.fillMaxWidth().background(Color(0xFFD5EAF3))) {
           // Box for overlaying the title on the image
           Box(modifier = Modifier.fillMaxWidth().height(LARGE_IMAGE_SIZE.dp)) {
-
+            var bitmaps by remember { mutableStateOf(listOf<Bitmap>()) }
+            LaunchedEffect(activity.uid) {
+              imageViewModel.fetchActivityImagesAsBitmaps(
+                  activity.uid, onSuccess = { urls -> bitmaps = urls }, onFailure = {})
+            }
             // Display the activity image
-            Image(
-                painter = painterResource(getImageResourceIdForCategory(activity.category)),
-                contentDescription = activity.title,
-                modifier = Modifier.fillMaxWidth().height(LARGE_IMAGE_SIZE.dp),
-                contentScale = ContentScale.Crop)
+            if (activity.images.isNotEmpty() && bitmaps.isNotEmpty()) {
+              Image(
+                  bitmap = bitmaps[0].asImageBitmap(),
+                  contentDescription = activity.title,
+                  modifier = Modifier.fillMaxWidth().height(LARGE_IMAGE_SIZE.dp),
+                  contentScale = ContentScale.FillWidth)
+            } else {
+              Image(
+                  painter = painterResource(getImageResourceIdForCategory(activity.category)),
+                  contentDescription = activity.title,
+                  modifier = Modifier.fillMaxWidth().height(LARGE_IMAGE_SIZE.dp),
+                  contentScale = ContentScale.Crop)
+            }
+
             // Apply a dark gradient overlay at the bottom to improve contrast
             DarkGradient()
 
@@ -599,4 +619,8 @@ fun DarkGradient() {
                       colors = listOf(Color.Transparent, Color.Black.copy(alpha = GRADIENT_MAX)),
                       startY = START_Y,
                       endY = END_Y)))
+}
+
+fun Bitmap.resizeToFixedSize(width: Int, height: Int): Bitmap {
+  return Bitmap.createScaledBitmap(this, width, height, true)
 }


### PR DESCRIPTION
In this PR: 
- First Image of the activity is displayed on the activity card, if it exists, else a default image is displayed.
- The Image is displayed in such a way that favors horizontal images over vertical images.
- A choice was made to keep the implementation of lazyColumn to display the activityCards in the overview rather than column. While the latest permits to upload all images at once, when first arriving on the screen, if there are too many activities, this is not scalable and could create a crash, hence I decided to go with the more secure option, even though images might take a fraction of second before appearing when the activity was not on the screen before.

### Overview Screen
![Capture d'écran 2024-12-20 001926](https://github.com/user-attachments/assets/dfb4e720-a184-4109-b9a7-3728263d6082)

### LikedActivities Screen
![Capture d'écran 2024-12-20 002040](https://github.com/user-attachments/assets/049dc175-c0ef-43b3-ba63-2bee3a6ea98c)
