### PR TITLE
Test/e2e test guest mode sign in out

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
@@ -11,13 +11,14 @@ import com.android.sample.model.image.ImageRepositoryFirestore
 import com.android.sample.model.map.LocationRepository
 import com.android.sample.model.map.PermissionChecker
 import com.android.sample.model.profile.ProfilesRepository
-import com.android.sample.resources.dummydata.defaultUserCredentials
+import com.android.sample.resources.dummydata.defaultUserCredentials1
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class ActivityFlowTest {
@@ -80,19 +81,44 @@ class ActivityFlowTest {
     hlp.click(Overview.SEGMENTED_BUTTON_(Category.SPORT))
     hlp.see(Overview.ACTIVITY_CARD)
 
+
     // Filter for specific criteria
-    // TODO: Implement this feature
+
+    hlp.see("filterDialog")
+    hlp.click("filterDialog")
+    hlp.see("FilterDialog")
+    hlp.scroll(
+        parentTag = "FilterDialog",
+        nodeTag = "onlyPROCheckboxRow")
+    hlp.see("onlyPROCheckbox")
+    hlp.click("onlyPROCheckbox")
+    hlp.scroll(
+        parentTag = "FilterDialog",
+        nodeTag = "filterButton")
+    hlp.click("filterButton")
+
+    hlp.notSee(Overview.ACTIVITY_CARD) // After filtering by PRO and SPORT, no activity is displayed
+    hlp.click(Overview.SEGMENTED_BUTTON_(Category.SKILLS)) // Switch to SKILLS
+    hlp.see(Overview.ACTIVITY_CARD)
+
+    //Search bar
+    hlp.click("searchBar")
+    hlp.write("searchBar","DANCE",)
+    hlp.notSee(Overview.ACTIVITY_CARD)
+    hlp.click("searchBar")
+    hlp.write("searchBar","Sample", replace = true)
+    hlp.see(Overview.ACTIVITY_CARD)
 
     // Open the activity details
     hlp.click(Overview.ACTIVITY_CARD)
 
-    // Activity details screen
-    /*hlp.assertIsDisplayed("activityDetailsScreen")
+    //Activity details screen
+    hlp.see("activityDetailsScreen")
     listOf(
       "topAppBar", "goBackButton", "image", "title", "titleText", "descriptionText",
       "price", "priceText", "location", "locationText", "schedule", "scheduleText"
-    ).forEach { hlp.assertIsDisplayed(it) }*/
-    // TODO: Implement this feature
+    ).forEach { hlp.see(it) }
+
 
     // Check that the user is not logged in and can't enroll
     hlp.scroll(
@@ -103,6 +129,36 @@ class ActivityFlowTest {
     hlp.notSee(Overview.ActivityDetails.ENROLL_BUTTON)
     hlp.click(Overview.ActivityDetails.GO_BACK_BUTTON)
     hlp.see(Overview.SCREEN)
+
+    //Check that the user do not have a profile
+    hlp.click(BottomNavigation.PROFILE, bottomNavItem = true)
+    hlp.see(Profile.NotLoggedIn.PROMPT)
+    hlp.see(Profile.NotLoggedIn.SIGN_IN_BUTTON)
+
+    // Check that the user is not logged in and has no liked activities
+    hlp.click(BottomNavigation.Liked, bottomNavItem = true)
+    hlp.notSee("activityCard")
+    hlp.see("notConnectedPrompt")
+    hlp.see("signInButton")
+
+
+    // Go To signIn
+
+    hlp.click("signInButton")
+    hlp.see(Auth.SignUp.SCREEN)
+    hlp.scroll(
+      Auth.SignUp.SIGN_UP_COLUMN,
+      Auth.SignUp.GO_TO_SIGN_IN_BUTTON)
+    hlp.click(Auth.SignUp.GO_TO_SIGN_IN_BUTTON)
+
+    // Auth screen > Sign in
+    hlp.see(Auth.SignIn.SCREEN)
+    hlp.scroll(
+      Auth.SignIn.SIGN_IN_COLUMN,
+      Auth.SignIn.GUEST_BUTTON)
+    hlp.click(Auth.SignIn.GUEST_BUTTON)
+
+
   }
 
   @Test
@@ -167,9 +223,9 @@ class ActivityFlowTest {
   fun aUserSignsInAndLooksAtTheirProfile() {
     // use of !! is allowed because this is a test environment and we know the
     // key exists. if it doesn't, it is up to the developer to fix the test
-    val email = defaultUserCredentials["email"]!!
-    val password = defaultUserCredentials["password"]!!
-    val name = defaultUserCredentials["first name"]!! // @TODO: Should this change to full name?
+    val email = defaultUserCredentials1["email"]!!
+    val password = defaultUserCredentials1["password"]!!
+    val name = defaultUserCredentials1["first name"]!! // @TODO: Should this change to full name?
 
     // Auth screen > Sign in screen
     hlp.click(Auth.SignIn.SIGN_IN_BUTTON)

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
@@ -12,6 +12,7 @@ import com.android.sample.model.map.LocationRepository
 import com.android.sample.model.map.PermissionChecker
 import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.resources.dummydata.defaultUserCredentials1
+import com.android.sample.resources.dummydata.defaultUserCredentials2
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
@@ -221,9 +222,9 @@ class ActivityFlowTest {
     val email1 = defaultUserCredentials1["email"]!!
     val password1 = defaultUserCredentials1["password"]!!
     val name1 = defaultUserCredentials1["first name"]!! // @TODO: Should this change to full name?
-    val email2 = defaultUserCredentials1["email"]!!
-    val password2 = defaultUserCredentials1["password"]!!
-    val name2 = defaultUserCredentials1["first name"]!!
+    val email2 = defaultUserCredentials2["email"]!!
+    val password2 = defaultUserCredentials2["password"]!!
+    val name2 = defaultUserCredentials2["first name"]!!
 
     // Auth screen > Sign in screen
     hlp.click(Auth.SignIn.SIGN_IN_BUTTON)
@@ -317,4 +318,5 @@ class ActivityFlowTest {
    }
 
   */
+
 }

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/ActivityFlowTest.kt
@@ -1,8 +1,6 @@
 package com.android.sample.ui.endtoend
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
 import com.android.sample.MainActivity
 import com.android.sample.model.activity.ActivitiesRepository
@@ -16,12 +14,10 @@ import com.android.sample.model.profile.ProfilesRepository
 import com.android.sample.resources.dummydata.defaultUserCredentials1
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import okhttp3.internal.wait
 import javax.inject.Inject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class ActivityFlowTest {
@@ -84,56 +80,60 @@ class ActivityFlowTest {
     hlp.click(Overview.SEGMENTED_BUTTON_(Category.SPORT))
     hlp.see(Overview.ACTIVITY_CARD)
 
-
     // Filter for specific criteria
 
     hlp.see(Overview.FILTER_DIALOG_BUTTON)
     hlp.click(Overview.FILTER_DIALOG_BUTTON)
     hlp.see(Overview.FILTER_DIALOG)
-    hlp.scroll(
-        parentTag = Overview.FILTER_DIALOG,
-        nodeTag = Overview.Filters.ONLY_PRO_CHECKBOX_ROW)
+    hlp.scroll(parentTag = Overview.FILTER_DIALOG, nodeTag = Overview.Filters.ONLY_PRO_CHECKBOX_ROW)
     hlp.see(Overview.Filters.ONLY_PRO_CHECKBOX_ROW)
     hlp.click(Overview.Filters.ONLY_PRO_CHECKBOX)
-    hlp.scroll(
-        parentTag = Overview.FILTER_DIALOG,
-        nodeTag = Overview.Filters.FILTER_BUTTON)
+    hlp.scroll(parentTag = Overview.FILTER_DIALOG, nodeTag = Overview.Filters.FILTER_BUTTON)
     hlp.click(Overview.Filters.FILTER_BUTTON)
 
     hlp.notSee(Overview.ACTIVITY_CARD) // After filtering by PRO and SPORT, no activity is displayed
     hlp.click(Overview.SEGMENTED_BUTTON_(Category.SKILLS)) // Switch to SKILLS
     hlp.see(Overview.ACTIVITY_CARD)
 
-    //Search bar
+    // Search bar
     hlp.click(Overview.SearchBar.SEARCH_BAR)
-    hlp.write(Overview.SearchBar.SEARCH_BAR,"DANCE",)
+    hlp.write(
+        Overview.SearchBar.SEARCH_BAR,
+        "DANCE",
+    )
     hlp.notSee(Overview.ACTIVITY_CARD)
     hlp.click(Overview.SearchBar.SEARCH_BAR)
-    hlp.write(Overview.SearchBar.SEARCH_BAR,"Sample", replace = true)
+    hlp.write(Overview.SearchBar.SEARCH_BAR, "Sample", replace = true)
     hlp.see(Overview.ACTIVITY_CARD)
 
     // Open the activity details
     hlp.click(Overview.ACTIVITY_CARD)
 
-    //Activity details screen
+    // Activity details screen
     hlp.see(ActivityDetails.SCREEN)
     listOf(
-      ActivityDetails.TopAppBar, ActivityDetails.GoBackButton, ActivityDetails.Image, ActivityDetails.Title, ActivityDetails.TitleText, ActivityDetails.DescriptionText,
-      ActivityDetails.Price, ActivityDetails.PriceText, ActivityDetails.Location, ActivityDetails.LocationText ,ActivityDetails.Schedule, ActivityDetails.ScheduleText
-    ).forEach { hlp.see(it) }
-
+            ActivityDetails.TopAppBar,
+            ActivityDetails.GoBackButton,
+            ActivityDetails.Image,
+            ActivityDetails.Title,
+            ActivityDetails.TitleText,
+            ActivityDetails.DescriptionText,
+            ActivityDetails.Price,
+            ActivityDetails.PriceText,
+            ActivityDetails.Location,
+            ActivityDetails.LocationText,
+            ActivityDetails.Schedule,
+            ActivityDetails.ScheduleText)
+        .forEach { hlp.see(it) }
 
     // Check that the user is not logged in and can't enroll
-    hlp.scroll(
-        Overview.ActivityDetails.SCREEN,
-        Overview.ActivityDetails
-            .NOT_LOGGED_IN_TEXT)
+    hlp.scroll(Overview.ActivityDetails.SCREEN, Overview.ActivityDetails.NOT_LOGGED_IN_TEXT)
     hlp.see(Overview.ActivityDetails.NOT_LOGGED_IN_TEXT)
     hlp.notSee(Overview.ActivityDetails.ENROLL_BUTTON)
     hlp.click(Overview.ActivityDetails.GO_BACK_BUTTON)
     hlp.see(Overview.SCREEN)
 
-    //Check that the user do not have a profile
+    // Check that the user do not have a profile
     hlp.click(BottomNavigation.PROFILE, bottomNavItem = true)
     hlp.see(Profile.NotLoggedIn.PROMPT)
     hlp.see(Profile.NotLoggedIn.SIGN_IN_BUTTON)
@@ -144,23 +144,16 @@ class ActivityFlowTest {
     hlp.see(Prompts.NOT_CONNECTED)
     hlp.see(Prompts.SignInButton)
 
-
     // Go To signIn
     hlp.click(Prompts.SignInButton)
     hlp.see(Auth.SignUp.SCREEN)
-    hlp.scroll(
-      Auth.SignUp.SIGN_UP_COLUMN,
-      Auth.SignUp.GO_TO_SIGN_IN_BUTTON)
+    hlp.scroll(Auth.SignUp.SIGN_UP_COLUMN, Auth.SignUp.GO_TO_SIGN_IN_BUTTON)
     hlp.click(Auth.SignUp.GO_TO_SIGN_IN_BUTTON)
 
     // Auth screen > Sign in
     hlp.see(Auth.SignIn.SCREEN)
-    hlp.scroll(
-      Auth.SignIn.SIGN_IN_COLUMN,
-      Auth.SignIn.GUEST_BUTTON)
+    hlp.scroll(Auth.SignIn.SIGN_IN_COLUMN, Auth.SignIn.GUEST_BUTTON)
     hlp.click(Auth.SignIn.GUEST_BUTTON)
-
-
   }
 
   @Test
@@ -226,10 +219,10 @@ class ActivityFlowTest {
     // use of !! is allowed because this is a test environment and we know the
     // key exists. if it doesn't, it is up to the developer to fix the test
     val email1 = defaultUserCredentials1["email"]!!
-    val password1= defaultUserCredentials1["password"]!!
+    val password1 = defaultUserCredentials1["password"]!!
     val name1 = defaultUserCredentials1["first name"]!! // @TODO: Should this change to full name?
     val email2 = defaultUserCredentials1["email"]!!
-    val password2= defaultUserCredentials1["password"]!!
+    val password2 = defaultUserCredentials1["password"]!!
     val name2 = defaultUserCredentials1["first name"]!!
 
     // Auth screen > Sign in screen
@@ -251,13 +244,13 @@ class ActivityFlowTest {
     hlp.see(Profile.SCREEN)
     hlp.see(name1, text = true)
 
-     //proceed to logout
+    // proceed to logout
     hlp.see(Profile.MORE_OPTIONS_BUTTON)
     hlp.click(Profile.MORE_OPTIONS_BUTTON)
     hlp.see(Profile.LOGOUT_BUTTON)
     hlp.click(Profile.LOGOUT_BUTTON)
 
-   // login with new credentials for user 2
+    // login with new credentials for user 2
     hlp.see(Auth.SignIn.SCREEN)
     hlp.write(Auth.SignIn.EMAIL_INPUT, email2)
     hlp.write(Auth.SignIn.PASSWORD_INPUT, password2)
@@ -267,12 +260,10 @@ class ActivityFlowTest {
     hlp.see(Overview.SCREEN)
     hlp.see(BottomNavigation.OVERVIEW)
 
-    //Profile screen of user 2
+    // Profile screen of user 2
     hlp.click(BottomNavigation.PROFILE, bottomNavItem = true)
     hlp.see(Profile.SCREEN)
     hlp.see(name2, text = true)
-
-
   }
 
   /*

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/ComposeTestHelper.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/ComposeTestHelper.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
 
 /**
  * Helper class to interact with the UI.
@@ -91,9 +92,19 @@ class ComposeTestHelper(private val composeTestRule: ComposeTestRule) {
     node.assertIsNotDisplayed()
   }
 
-  /** Writes text in a node with the given tag. */
-  fun write(tag: String, input: String) {
-    composeTestRule.onNodeWithTag(tag).performTextInput(input)
+  /**
+   * Writes text to a node with the given tag.
+   *
+   * @param tag The tag of the node to write to.
+   * @param input The text to write.
+   * @param replace Whether to replace the text in the node. default is false.
+   */
+  fun write(tag: String, input: String, replace: Boolean = false) {
+    when(replace){
+      true -> composeTestRule.onNodeWithTag(tag).performTextReplacement(input)
+      false -> composeTestRule.onNodeWithTag(tag).performTextInput(input)
+    }
     composeTestRule.waitForIdle()
   }
+
 }

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/ComposeTestHelper.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/ComposeTestHelper.kt
@@ -100,11 +100,10 @@ class ComposeTestHelper(private val composeTestRule: ComposeTestRule) {
    * @param replace Whether to replace the text in the node. default is false.
    */
   fun write(tag: String, input: String, replace: Boolean = false) {
-    when(replace){
+    when (replace) {
       true -> composeTestRule.onNodeWithTag(tag).performTextReplacement(input)
       false -> composeTestRule.onNodeWithTag(tag).performTextInput(input)
     }
     composeTestRule.waitForIdle()
   }
-
 }

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/TestTags.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/TestTags.kt
@@ -45,6 +45,18 @@ object Overview {
   const val SCREEN = "listActivitiesScreen"
   const val ACTIVITY_CARD = "activityCard"
   const val SEGMENTED_BUTTON_ROW = "segmentedButtonRow"
+  const val FILTER_DIALOG_BUTTON="filterDialog"
+  const val FILTER_DIALOG="FilterDialog"
+  object Filters{
+    const val ONLY_PRO_CHECKBOX_ROW="onlyPROCheckboxRow"
+    const val ONLY_PRO_CHECKBOX="onlyPROCheckbox"
+    const val FILTER_BUTTON="filterButton"
+  }
+
+  object SearchBar{
+    const val SEARCH_BAR="searchBar"
+
+  }
 
   fun SEGMENTED_BUTTON_(type: Category) = "segmentedButton${type.name}"
 
@@ -72,6 +84,8 @@ object Overview {
 /** Profile tags */
 object Profile {
   const val SCREEN = "profileScreen"
+  const val MORE_OPTIONS_BUTTON="moreOptionsButton"
+  const val LOGOUT_BUTTON = "logoutMenuItem"
 
   object NotLoggedIn {
     const val PROMPT = "loadingText"
@@ -85,6 +99,7 @@ object NoConnection {
 
 /** Activity details tags */
 object ActivityDetails {
+  const val SCREEN="activityDetailsScreen"
   const val TopAppBar = "topAppBar"
   const val Image = "image"
   const val Title = "title"
@@ -96,6 +111,8 @@ object ActivityDetails {
   const val LocationText = "locationText"
   const val Schedule = "schedule"
   const val ScheduleText = "scheduleText"
+  const val GoBackButton="goBackButton"
+
 }
 
 // Inputs
@@ -128,4 +145,10 @@ object Prompts {
 object Map {
   const val Map = "Map"
   const val CenterOnCurrentLocation = "centerOnCurrentLocation"
+}
+
+// Liked Activities
+object LikedActivities{
+    const val SCREEN="likedActivitiesScreen"
+    const val ACTIVITY_CARD="activityCard"
 }

--- a/app/src/androidTest/java/com/android/sample/ui/endtoend/TestTags.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/endtoend/TestTags.kt
@@ -45,17 +45,17 @@ object Overview {
   const val SCREEN = "listActivitiesScreen"
   const val ACTIVITY_CARD = "activityCard"
   const val SEGMENTED_BUTTON_ROW = "segmentedButtonRow"
-  const val FILTER_DIALOG_BUTTON="filterDialog"
-  const val FILTER_DIALOG="FilterDialog"
-  object Filters{
-    const val ONLY_PRO_CHECKBOX_ROW="onlyPROCheckboxRow"
-    const val ONLY_PRO_CHECKBOX="onlyPROCheckbox"
-    const val FILTER_BUTTON="filterButton"
+  const val FILTER_DIALOG_BUTTON = "filterDialog"
+  const val FILTER_DIALOG = "FilterDialog"
+
+  object Filters {
+    const val ONLY_PRO_CHECKBOX_ROW = "onlyPROCheckboxRow"
+    const val ONLY_PRO_CHECKBOX = "onlyPROCheckbox"
+    const val FILTER_BUTTON = "filterButton"
   }
 
-  object SearchBar{
-    const val SEARCH_BAR="searchBar"
-
+  object SearchBar {
+    const val SEARCH_BAR = "searchBar"
   }
 
   fun SEGMENTED_BUTTON_(type: Category) = "segmentedButton${type.name}"
@@ -84,7 +84,7 @@ object Overview {
 /** Profile tags */
 object Profile {
   const val SCREEN = "profileScreen"
-  const val MORE_OPTIONS_BUTTON="moreOptionsButton"
+  const val MORE_OPTIONS_BUTTON = "moreOptionsButton"
   const val LOGOUT_BUTTON = "logoutMenuItem"
 
   object NotLoggedIn {
@@ -99,7 +99,7 @@ object NoConnection {
 
 /** Activity details tags */
 object ActivityDetails {
-  const val SCREEN="activityDetailsScreen"
+  const val SCREEN = "activityDetailsScreen"
   const val TopAppBar = "topAppBar"
   const val Image = "image"
   const val Title = "title"
@@ -111,8 +111,7 @@ object ActivityDetails {
   const val LocationText = "locationText"
   const val Schedule = "schedule"
   const val ScheduleText = "scheduleText"
-  const val GoBackButton="goBackButton"
-
+  const val GoBackButton = "goBackButton"
 }
 
 // Inputs
@@ -148,7 +147,7 @@ object Map {
 }
 
 // Liked Activities
-object LikedActivities{
-    const val SCREEN="likedActivitiesScreen"
-    const val ACTIVITY_CARD="activityCard"
+object LikedActivities {
+  const val SCREEN = "likedActivitiesScreen"
+  const val ACTIVITY_CARD = "activityCard"
 }

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -52,8 +52,7 @@ class ProfileScreenTest {
   private lateinit var mockImageViewModel: ImageViewModel
   private lateinit var mockImageRepository: ImageRepositoryFirestore
   private lateinit var mockHourDateViewModel: HourDateViewModel
-    private lateinit var signInViewModel: SignInViewModel
-
+  private lateinit var signInViewModel: SignInViewModel
 
   private lateinit var sharedPreferences: SharedPreferences
   private lateinit var mockEditor: SharedPreferences.Editor
@@ -83,7 +82,7 @@ class ProfileScreenTest {
     }
 
     listActivitiesViewModel.getActivities()
-      signInViewModel = mock(SignInViewModel::class.java)
+    signInViewModel = mock(SignInViewModel::class.java)
     val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTests.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.performClick
 import com.android.sample.model.activity.ActivitiesRepository
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.auth.SignInViewModel
 import com.android.sample.model.hour_date.HourDateViewModel
 import com.android.sample.model.image.ImageRepositoryFirestore
 import com.android.sample.model.image.ImageViewModel
@@ -51,6 +52,8 @@ class ProfileScreenTest {
   private lateinit var mockImageViewModel: ImageViewModel
   private lateinit var mockImageRepository: ImageRepositoryFirestore
   private lateinit var mockHourDateViewModel: HourDateViewModel
+    private lateinit var signInViewModel: SignInViewModel
+
 
   private lateinit var sharedPreferences: SharedPreferences
   private lateinit var mockEditor: SharedPreferences.Editor
@@ -80,6 +83,7 @@ class ProfileScreenTest {
     }
 
     listActivitiesViewModel.getActivities()
+      signInViewModel = mock(SignInViewModel::class.java)
     val userStateFlow = MutableStateFlow(testUser)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
@@ -102,7 +106,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
     composeTestRule
         .onNodeWithTag("loadingText")
@@ -118,7 +123,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
     composeTestRule.onNodeWithTag("profileTopBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("userName").assertIsDisplayed()
@@ -142,7 +148,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
     composeTestRule.onNodeWithTag("settingsIcon", useUnmergedTree = true).performClick()
     composeTestRule.onNodeWithTag("editProfileMenuItem").performClick()
@@ -156,7 +163,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
 
     // Wait until the UI is idle and ready
@@ -184,7 +192,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
     composeTestRule.onNodeWithTag("passedActivities").performClick()
     composeTestRule.onNodeWithText("Watch World Cup 2022", useUnmergedTree = true).assertExists()
@@ -202,7 +211,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
 
     composeTestRule.waitForIdle()
@@ -295,7 +305,8 @@ class ProfileScreenTest {
           userProfileViewModel = userProfileViewModel,
           navigationActions = navigationActions,
           listActivitiesViewModel = listActivitiesViewModel,
-          imageViewModel = mockImageViewModel)
+          imageViewModel = mockImageViewModel,
+          signInViewModel = signInViewModel)
     }
 
     // Wait for the UI to settle

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -166,7 +166,11 @@ fun NavGraph(
       }
       composable(Screen.PARTICIPANT_PROFILE) {
         ParticipantProfileScreen(
-            listActivitiesViewModel, navigationActions, imageViewModel, profileViewModel, authViewModel)
+            listActivitiesViewModel,
+            navigationActions,
+            imageViewModel,
+            profileViewModel,
+            authViewModel)
       }
     }
 
@@ -198,7 +202,7 @@ fun NavGraph(
             navigationActions = navigationActions,
             listActivitiesViewModel = listActivitiesViewModel,
             imageViewModel = imageViewModel,
-             signInViewModel = authViewModel)
+            signInViewModel = authViewModel)
       }
       composable(Screen.EDIT_PROFILE) {
         EditProfileScreen(profileViewModel, navigationActions, imageViewModel)

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -166,7 +166,7 @@ fun NavGraph(
       }
       composable(Screen.PARTICIPANT_PROFILE) {
         ParticipantProfileScreen(
-            listActivitiesViewModel, navigationActions, imageViewModel, profileViewModel)
+            listActivitiesViewModel, navigationActions, imageViewModel, profileViewModel, authViewModel)
       }
     }
 
@@ -197,7 +197,8 @@ fun NavGraph(
             userProfileViewModel = profileViewModel,
             navigationActions = navigationActions,
             listActivitiesViewModel = listActivitiesViewModel,
-            imageViewModel = imageViewModel)
+            imageViewModel = imageViewModel,
+             signInViewModel = authViewModel)
       }
       composable(Screen.EDIT_PROFILE) {
         EditProfileScreen(profileViewModel, navigationActions, imageViewModel)

--- a/app/src/main/java/com/android/sample/model/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/auth/SignInViewModel.kt
@@ -60,14 +60,10 @@ constructor(
     }
   }
 
-  /**
-   * Checks if a user profile exists in the `ProfilesRepository`.
-   *
-   * @param uid The unique user ID obtained after authentication.
-   * @param onProfileExists Callback invoked if the profile exists.
-   * @param onProfileMissing Callback invoked if the profile is missing.
-   * @param onFailure Callback invoked on failure with an error message.
-   */
+  fun signOut() {
+    signInRepository.signOut()
+  }
+
   private fun checkUserProfile(
       uid: String?,
       onProfileExists: () -> Unit,
@@ -75,7 +71,6 @@ constructor(
       onFailure: (String) -> Unit
   ) {
     uid?.let {
-      // Fetch the user profile from the repository
       profilesRepository.getUser(
           it,
           { user ->

--- a/app/src/main/java/com/android/sample/resources/dummydata/E2E_DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/E2E_DummyData.kt
@@ -125,7 +125,6 @@ val defaultUserCredentials2 =
         "first name" to e2e_user2.name,
         "full name" to "${e2e_user2.name} ${e2e_user2.surname}")
 
-
 val e2e_Users = listOf(e2e_user1, e2e_user2)
 val e2e_Activities = listOf(e2e_activity1, e2e_activity2)
 val e2e_Credentials =

--- a/app/src/main/java/com/android/sample/resources/dummydata/E2E_DummyData.kt
+++ b/app/src/main/java/com/android/sample/resources/dummydata/E2E_DummyData.kt
@@ -112,12 +112,19 @@ private val e2e_activity2 =
         participants = listOf(e2e_user1),
         comments = listOf(e2e_comment1))
 
-val defaultUserCredentials =
+val defaultUserCredentials1 =
     mapOf(
         "email" to e2e_user1_email,
         "password" to e2e_user1_password,
         "first name" to e2e_user1.name,
         "full name" to "${e2e_user1.name} ${e2e_user1.surname}")
+val defaultUserCredentials2 =
+    mapOf(
+        "email" to e2e_user2_email,
+        "password" to e2e_user2_password,
+        "first name" to e2e_user2.name,
+        "full name" to "${e2e_user2.name} ${e2e_user2.surname}")
+
 
 val e2e_Users = listOf(e2e_user1, e2e_user2)
 val e2e_Activities = listOf(e2e_activity1, e2e_activity2)

--- a/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.sample.model.activity.ListActivitiesViewModel
+import com.android.sample.model.auth.SignInViewModel
 import com.android.sample.model.image.ImageViewModel
 import com.android.sample.model.profile.ProfileViewModel
 import com.android.sample.ui.navigation.NavigationActions
@@ -27,7 +28,8 @@ fun ParticipantProfileScreen(
     listActivitiesViewModel: ListActivitiesViewModel,
     navigationActions: NavigationActions,
     imageViewModel: ImageViewModel,
-    profileViewModel: ProfileViewModel
+    profileViewModel: ProfileViewModel,
+    signInViewModel: SignInViewModel
 ) {
 
   val selectedParticipant = listActivitiesViewModel.selectedUser.collectAsState().value
@@ -37,7 +39,8 @@ fun ParticipantProfileScreen(
         profileViewModel,
         navigationActions,
         listActivitiesViewModel,
-        imageViewModel)
+        imageViewModel,
+         signInViewModel)
   }
 }
 

--- a/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ParticipantProfile.kt
@@ -40,7 +40,7 @@ fun ParticipantProfileScreen(
         navigationActions,
         listActivitiesViewModel,
         imageViewModel,
-         signInViewModel)
+        signInViewModel)
   }
 }
 

--- a/app/src/main/java/com/android/sample/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/Profile.kt
@@ -3,7 +3,6 @@ package com.android.sample.ui.profile
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -40,7 +39,6 @@ import androidx.compose.ui.unit.sp
 import com.android.sample.R
 import com.android.sample.model.activity.Activity
 import com.android.sample.model.activity.ListActivitiesViewModel
-import com.android.sample.model.auth.SignInRepository
 import com.android.sample.model.auth.SignInViewModel
 import com.android.sample.model.hour_date.HourDateViewModel
 import com.android.sample.model.image.ImageViewModel
@@ -83,8 +81,6 @@ import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Route
 import com.android.sample.ui.navigation.Screen
 import com.google.firebase.Timestamp
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.ktx.Firebase
 import java.util.Calendar
 
 @Composable
@@ -123,7 +119,8 @@ fun ProfileScreen(
             imageViewModel,
             userProfileViewModel,
             listActivitiesViewModel,
-            uid, signInViewModel  )
+            uid,
+            signInViewModel)
       }
     }
   } else {
@@ -438,8 +435,7 @@ fun UserProfile(
                 DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
                   DropdownMenuItem(
                       modifier = Modifier.testTag("logoutMenuItem"),
-                      text = {
-                          Text(LocalContext.current.getString(R.string.logout)) },
+                      text = { Text(LocalContext.current.getString(R.string.logout)) },
                       onClick = {
                         performOfflineAwareAction(
                             context = context,
@@ -447,17 +443,15 @@ fun UserProfile(
                             onPerform = {
                               showMenu = false
                               profileViewModel.clearUserData()
-                              signInViewModel.signOut() //sign out
+                              signInViewModel.signOut() // sign out
                               navigationActions.navigateTo(Screen.AUTH)
-
                             })
                       },
-                      enabled = profileViewModel.userState.value!=null)
+                      enabled = profileViewModel.userState.value != null)
                   DropdownMenuItem(
                       modifier = Modifier.testTag("editProfileMenuItem"),
                       text = { Text(LocalContext.current.getString(R.string.edit_profile)) },
-                      onClick = {
-                          navigationActions.navigateTo(Screen.EDIT_PROFILE) })
+                      onClick = { navigationActions.navigateTo(Screen.EDIT_PROFILE) })
                 }
               }
             })


### PR DESCRIPTION


## Summary

This pull request introduces 2 end 2 ends, hre are their description:



---

### **1. `aUserSwitchesProfile`**

**Purpose:** Test logging out of one account and logging into another.

1. **User 1 Login:**
   - Navigate to the Sign-In screen and enter User 1 credentials.
   - Verify navigation to the **Overview screen**.
   - Go to the **Profile** tab and confirm User 1's name is displayed.

2. **Log Out User 1:**
   - Use the **More Options** menu to log out.
   - Verify return to the **Sign-In screen**.

3. **User 2 Login:**
   - Enter User 2 credentials and log in.
   - Verify navigation to the **Overview screen**.
   - Go to the **Profile** tab and confirm User 2's name is displayed.

---

### **2. `guestCanSeeCorrectOverviewAndNavigateToActivityDetails`**

**Purpose:** Test guest navigation and feature restrictions.

1. **Guest Login:**
   - Click **Guest Sign-In** and verify navigation to the **Overview screen**.

2. **Filter and Search Activities:**
   - Apply category filters (e.g., **Sport**).
   - Use search functionality, including the `replace` feature, to refine results.

3. **View Activity Details:**
   - Click an activity card and verify key details are displayed.
   - Confirm guest restrictions (e.g., no **Enroll** button).

4. **Guest Profile and Liked Activities:**
   - Navigate to **Profile** and **Liked Activities** tabs to confirm prompts to sign in.

5. **Restart Guest Session:**
   - Return to **Sign-In** and re-enter as a guest. Verify navigation to **Overview**.

## Changes Made in the overall code

 **Refactoring:**
   - Updated `SignInViewModel` usage to replace direct calls to `Firebase.auth`, adhering to MVVM principles.
   - Applied `ktfmt` for consistent code formatting.
   
   closes #440 
