### PR TITLE
fix/activityDetails/creator fetching

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -32,6 +32,7 @@ import com.android.sample.model.profile.User
 import com.android.sample.model.profile.database.UserDao
 import com.android.sample.resources.dummydata.activityListWithPastActivity
 import com.android.sample.resources.dummydata.activityWithParticipants
+import com.android.sample.resources.dummydata.simpleUser
 import com.android.sample.resources.dummydata.testUser
 import com.android.sample.ui.activitydetails.ActivityDetailsScreen
 import com.android.sample.ui.activitydetails.CreatorRow
@@ -84,7 +85,7 @@ class ActivityDetailsScreenAndroidTest {
 
     mockViewModel = mock(ListActivitiesViewModel::class.java)
 
-    val activityStateFlow = MutableStateFlow(activityWithParticipants)
+    val activityStateFlow = MutableStateFlow(activityWithParticipants.copy(creator = "1"))
     `when`(mockViewModel.selectedActivity).thenReturn(activityStateFlow)
 
     mockDefaultUiState =
@@ -158,7 +159,8 @@ class ActivityDetailsScreenAndroidTest {
     mockProfileViewModel = mock(ProfileViewModel::class.java)
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     val activityFinished = activityWithParticipants.copy(status = ActivityStatus.FINISHED)
-    `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activityFinished))
+    `when`(mockViewModel.selectedActivity)
+        .thenReturn(MutableStateFlow(activityFinished.copy(creator = "1")))
     composeTestRule.setContent {
       ActivityDetailsScreen(
           listActivityViewModel = mockViewModel,
@@ -217,7 +219,7 @@ class ActivityDetailsScreenAndroidTest {
 
     val activity =
         activityWithParticipants.copy(
-            creator = "456", // Different from user ID
+            creator = "1", // Different from user ID
             status = ActivityStatus.ACTIVE)
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
 
@@ -240,7 +242,9 @@ class ActivityDetailsScreenAndroidTest {
   fun editButton_displaysForActiveActivity_whenUserIsTheCreator() {
     mockProfileViewModel = mock(ProfileViewModel::class.java)
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser.copy(id = "123")))
-    val activity1 = activityWithParticipants.copy(creator = "123")
+    val activity1 =
+        activityWithParticipants.copy(
+            creator = "123", participants = listOf(testUser.copy(id = "123")))
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity1))
 
     composeTestRule.setContent {
@@ -291,7 +295,8 @@ class ActivityDetailsScreenAndroidTest {
     `when`(mockProfileViewModel.userState).thenReturn(MutableStateFlow(testUser))
     // Set placesLeft equal to maxPlaces to simulate full capacity
     val activityWithMaxParticipants =
-        activityWithParticipants.copy(placesLeft = activityWithParticipants.maxPlaces)
+        activityWithParticipants.copy(
+            placesLeft = activityWithParticipants.maxPlaces, creator = "1")
     val activityStateFlow = MutableStateFlow(activityWithMaxParticipants)
     `when`(mockViewModel.selectedActivity).thenReturn(activityStateFlow)
 
@@ -321,7 +326,7 @@ class ActivityDetailsScreenAndroidTest {
     val activity =
         activityWithParticipants.copy(
             uid = "act1",
-            creator = "456", // Different from user ID
+            creator = "1", // Different from user ID
             status = ActivityStatus.ACTIVE)
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
 
@@ -383,7 +388,9 @@ class ActivityDetailsScreenAndroidTest {
 
     val activity =
         activityWithParticipants.copy(
-            creator = "456", status = ActivityStatus.ACTIVE, participants = listOf(testUser))
+            creator = "JohnDoe",
+            status = ActivityStatus.ACTIVE,
+            participants = listOf(testUser, simpleUser.copy(id = "JohnDoe")))
     `when`(mockViewModel.selectedActivity).thenReturn(MutableStateFlow(activity))
 
     composeTestRule.setContent {

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -164,9 +164,20 @@ fun ActivityDetailsScreen(
 
   val creatorID = activity?.creator ?: ""
   var creator by remember {
-    mutableStateOf(User(creatorID, "anonymous", "anonymous", listOf(), listOf(), "", listOf()))
+    mutableStateOf(User(creatorID, "null", "null", listOf(), listOf(), "", listOf()))
   }
+
   activity?.participants?.firstOrNull { it.id == creatorID }?.let { creator = it }
+  if (creator.name == "null") {
+    profileViewModel.getUserData(
+        creatorID,
+        onResult = {
+          if (it != null) {
+            creator = it
+          }
+        })
+  }
+  Log.d("ActivityDetailsScreen", "ActivityDetails Creator: $creator")
   val uiState by listActivityViewModel.uiState.collectAsState()
   val activitiesList = (uiState as ListActivitiesViewModel.ActivitiesUiState.Success).activities
   val nbActivitiesCreated = activitiesList.filter { it.creator == creator.id }.size


### PR DESCRIPTION
In this PR : 
- I fetch the creator informationswhen he is not in participant's list. Before, the only way to get the creator was to iterate on the participant's list, however it was introduced the possibility for the creator to leave the activity, or not be in it when in PRO. Now I have to call this method to getUserData when the creator is not in the participant's list.

- I Adjusted tests so that the clause where the creator is not in the list of participant never gets accessed in the tests because mocking this behavior is too complex and time worthy.