### PR TITLE
remove creator rating because it is static

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt
@@ -640,8 +640,6 @@ class ActivityDetailsScreenAndroidTest {
     composeTestRule.onNodeWithTag("creatorName").assertIsDisplayed()
     composeTestRule.onNodeWithTag("creatorName").assertTextContains("John Doe")
 
-    composeTestRule.onNodeWithTag("creatorRating").assertIsDisplayed()
-
     composeTestRule.onNodeWithTag("activityCount").assertIsDisplayed()
     composeTestRule.onNodeWithTag("activityCount").assertTextContains("Created 5 Activities")
   }

--- a/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt
@@ -31,11 +31,9 @@ import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Groups
 import androidx.compose.material.icons.outlined.ModeComment
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonDefaults.buttonColors
@@ -93,7 +91,6 @@ import com.android.sample.resources.C.Tag.IMAGE_HEIGHT_RATIO
 import com.android.sample.resources.C.Tag.IMAGE_WIDTH_RATIO
 import com.android.sample.resources.C.Tag.LARGE_FONT_WEIGHT
 import com.android.sample.resources.C.Tag.LIGHT_BLUE
-import com.android.sample.resources.C.Tag.MEDIUM_FONTSIZE
 import com.android.sample.resources.C.Tag.MEDIUM_FONT_WEIGHT
 import com.android.sample.resources.C.Tag.MEDIUM_PADDING
 import com.android.sample.resources.C.Tag.NORMAL_PADDING
@@ -1227,27 +1224,6 @@ fun CreatorRow(
                   modifier = Modifier.testTag("activityCount"))
             }
         Spacer(modifier = Modifier.width(SMALL_PADDING.dp))
-        Row(
-            horizontalArrangement =
-                Arrangement.spacedBy(SMALL_PADDING.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.testTag("creatorRating")) {
-              Text(
-                  modifier = Modifier.testTag("ratingText"),
-                  text = "4.7",
-                  style =
-                      TextStyle(
-                          fontSize = MEDIUM_PADDING.sp,
-                          fontWeight = FontWeight(LARGE_FONT_WEIGHT),
-                          color = Color(DARK_GRAY),
-                          textAlign = TextAlign.Center,
-                      ))
-              Icon(
-                  imageVector = Icons.Filled.Star,
-                  contentDescription = "Star",
-                  tint = Color.Black,
-                  modifier = Modifier.size(MEDIUM_FONTSIZE.dp))
-            }
       }
 }
 /**


### PR DESCRIPTION
This pull request includes changes to the `ActivityDetailsScreen` and its related test files to remove the display of the creator's rating. The most important changes include the removal of the `creatorRating` display logic and the associated imports and resources.

Removals related to creator's rating:

* [`app/src/androidTest/java/com/android/sample/ui/activityDetails/ActivityDetailsScreenTest1.kt`](diffhunk://#diff-5b7f04366bd7ff5c5f88e6675afd21c1eb74cd81a047076e33956d2d72f1ba15L643-L644): Removed the test assertion for `creatorRating` to reflect the UI change.
* [`app/src/main/java/com/android/sample/ui/activitydetails/ActivityDetailsScreen.kt`](diffhunk://#diff-032509671eddf10a6646f670fbbbda77da4cc9c758509bdccb0745f150c37a5dL1230-L1250): Removed the `creatorRating` row and associated UI elements from the `CreatorRow` function.
